### PR TITLE
feat: set up CodeRabbit AI review + PR automation (assignee, reviewer, CODEOWNERS)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+language: "ko"
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!**/*.lock"
+    - "!**/testdata/**"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+*                @ydking0911
+
+/sdk/python/     @ydking0911
+/sdk/node/       @ydking0911
+/server/         @ydking0911
+/dashboard/      @ydking0911

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
 
     steps:
       - name: Auto-assign author as assignee

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,34 @@
+name: PR Automation
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Auto-assign author as assignee
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [pr.user.login]
+            });
+
+            if (pr.user.login !== 'ydking0911') {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                reviewers: ['ydking0911']
+              });
+            }


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml`: enables automatic AI code review in Korean on every PR, excluding lock files and testdata paths
- Add `.github/workflows/pr-automation.yml`: auto-assigns the PR author as assignee on open/ready-for-review; requests `ydking0911` as reviewer for PRs from external contributors
- Add `.github/CODEOWNERS`: designates `ydking0911` as code owner across all major paths

Closes #22

## Test plan

- [ ] Install the CodeRabbit GitHub App on this repo and open a new PR to verify AI review comments appear
- [ ] Verify the PR author is automatically set as assignee when a PR is opened (`pr-automation` workflow)
- [ ] Verify `ydking0911` is automatically requested as reviewer on PRs from external contributors
- [ ] Enable "Require review from Code Owners" in the branch ruleset for `develop` and `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * PR 자동 할당 및 검토 요청 워크플로우 추가
  * 코드 소유권(CODEOWNERS) 구성 추가/갱신
  * 코드 리뷰 시스템 언어를 한국어로 설정하고 자동 검토 및 경로 필터 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/23)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/23)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->