### PR TITLE
feat: add agent_span / agentSpan helper with standard attribute convention (#19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,49 @@ Components:
 
 ---
 
+## Agent Observability Attribute Convention
+
+Use `agent_span()` (Python) or `agentSpan()` (Node.js) for agent action spans. These are thin wrappers over `span()` that pre-populate standard attribute keys.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `agent.intent` | string | Goal the agent is working toward (e.g. `"summarize document"`) |
+| `agent.trigger` | string | What caused this action: `user_message`, `tool_result`, or a prior `span_id` |
+| `agent.model` | string | LLM that made the decision (e.g. `"claude-sonnet-4-6"`) |
+| `agent.tool` | string | Tool being invoked (e.g. `"web_search"`) |
+
+All keys are optional — omit any that aren't relevant to the span.
+
+**Python:**
+```python
+with client.agent_span(
+    "tool.call",
+    intent="find recent observability papers",
+    trigger="user_message",
+    model="claude-sonnet-4-6",
+    tool="web_search",
+) as span:
+    results = web_search(...)
+    span.set_attribute("result_count", len(results))
+```
+
+**Node.js:**
+```ts
+await client.agentSpan("tool.call", {
+  intent: "find recent observability papers",
+  trigger: "user_message",
+  model: "claude-sonnet-4-6",
+  tool: "web_search",
+}).run(async (span) => {
+  const results = await webSearch(...);
+  span.setAttribute("result_count", results.length);
+});
+```
+
+Context propagation works identically to `span()` — nesting inside another span auto-inherits `parent_span_id` and `trace_id`.
+
+---
+
 ## Verified Commands
 
 Before running any command, `cd` to the correct directory.

--- a/sdk/node/src/client.ts
+++ b/sdk/node/src/client.ts
@@ -33,6 +33,34 @@ export class ObservrClient {
     return new Span(name, this.transport, attributes);
   }
 
+  /**
+   * Span for agent actions with standard attribute keys.
+   *
+   * Standard keys (omitted when undefined):
+   *   agent.intent   — goal the agent is working toward
+   *   agent.trigger  — what caused this action (user_message | tool_result | <span_id>)
+   *   agent.model    — LLM that made the decision
+   *   agent.tool     — tool being invoked
+   */
+  agentSpan(
+    name: string,
+    options: {
+      intent?: string;
+      trigger?: string;
+      model?: string;
+      tool?: string;
+      [key: string]: unknown;
+    } = {}
+  ): Span {
+    const { intent, trigger, model, tool, ...extra } = options;
+    const attributes: Record<string, unknown> = { ...extra };
+    if (intent !== undefined) attributes["agent.intent"] = intent;
+    if (trigger !== undefined) attributes["agent.trigger"] = trigger;
+    if (model !== undefined) attributes["agent.model"] = model;
+    if (tool !== undefined) attributes["agent.tool"] = tool;
+    return new Span(name, this.transport, attributes);
+  }
+
   async shutdown(): Promise<void> {
     unpatchConsole();
     await this.transport.shutdown();

--- a/sdk/node/tests/agent-span.test.ts
+++ b/sdk/node/tests/agent-span.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ObservrClient } from "../src/client.js";
+import { Transport } from "../src/transport.js";
+
+describe("agentSpan()", () => {
+  let client: ObservrClient;
+  let sendSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    client = new ObservrClient({
+      service: "test",
+      collectorUrl: "http://localhost:7676",
+      autoInstrument: false,
+      logLevel: "debug",
+    });
+    sendSpy = vi.spyOn(client.transport, "send");
+  });
+
+  afterEach(async () => {
+    await client.shutdown();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Standard attributes ──────────────────────────────────────────────────
+
+  it("sets agent.intent", async () => {
+    await client.agentSpan("decide", { intent: "summarize document" }).run(async () => {});
+    expect(sendSpy.mock.calls[0][0].attributes?.["agent.intent"]).toBe("summarize document");
+  });
+
+  it("sets agent.trigger", async () => {
+    await client.agentSpan("decide", { trigger: "user_message" }).run(async () => {});
+    expect(sendSpy.mock.calls[0][0].attributes?.["agent.trigger"]).toBe("user_message");
+  });
+
+  it("sets agent.model", async () => {
+    await client.agentSpan("decide", { model: "claude-sonnet-4-6" }).run(async () => {});
+    expect(sendSpy.mock.calls[0][0].attributes?.["agent.model"]).toBe("claude-sonnet-4-6");
+  });
+
+  it("sets agent.tool", async () => {
+    await client.agentSpan("tool.call", { tool: "web_search" }).run(async () => {});
+    expect(sendSpy.mock.calls[0][0].attributes?.["agent.tool"]).toBe("web_search");
+  });
+
+  it("sets all standard attributes at once", async () => {
+    await client.agentSpan("tool.call", {
+      intent: "find papers",
+      trigger: "user_message",
+      model: "claude-sonnet-4-6",
+      tool: "web_search",
+    }).run(async () => {});
+    const attrs = sendSpy.mock.calls[0][0].attributes ?? {};
+    expect(attrs["agent.intent"]).toBe("find papers");
+    expect(attrs["agent.trigger"]).toBe("user_message");
+    expect(attrs["agent.model"]).toBe("claude-sonnet-4-6");
+    expect(attrs["agent.tool"]).toBe("web_search");
+  });
+
+  it("omits undefined standard attributes", async () => {
+    await client.agentSpan("decide", { intent: "summarize" }).run(async () => {});
+    const attrs = sendSpy.mock.calls[0][0].attributes ?? {};
+    expect(attrs).not.toHaveProperty("agent.trigger");
+    expect(attrs).not.toHaveProperty("agent.model");
+    expect(attrs).not.toHaveProperty("agent.tool");
+  });
+
+  // ── Extra attributes pass through ────────────────────────────────────────
+
+  it("forwards extra attributes", async () => {
+    await client.agentSpan("decide", { intent: "summarize", result_count: 5 }).run(async () => {});
+    const attrs = sendSpy.mock.calls[0][0].attributes ?? {};
+    expect(attrs["result_count"]).toBe(5);
+    expect(attrs["agent.intent"]).toBe("summarize");
+  });
+
+  // ── Context propagation ──────────────────────────────────────────────────
+
+  it("inherits parent context automatically", async () => {
+    let innerParentId: string | undefined;
+    let outerSpanId: string | undefined;
+
+    await client.span("outer").run(async (outer) => {
+      outerSpanId = outer.spanId;
+      const inner = client.agentSpan("inner", { intent: "sub-task" });
+      innerParentId = inner.parentSpanId;
+      await inner.run(async () => {});
+    });
+
+    expect(innerParentId).toBe(outerSpanId);
+  });
+
+  // ── Emitted event shape ──────────────────────────────────────────────────
+
+  it("emits span type with correct message", async () => {
+    await client.agentSpan("agent.decide", { intent: "summarize" }).run(async () => {});
+    const event = sendSpy.mock.calls[0][0];
+    expect(event.type).toBe("span");
+    expect(event.message).toBe("agent.decide");
+  });
+});

--- a/sdk/python/observr/_client.py
+++ b/sdk/python/observr/_client.py
@@ -203,7 +203,7 @@ class ObservrClient:
             agent.model    — LLM that made the decision
             agent.tool     — tool being invoked
         """
-        attrs: dict[str, object] = {}
+        attrs: dict[str, object] = dict(extra_attributes)
         if intent is not None:
             attrs["agent.intent"] = intent
         if trigger is not None:
@@ -212,5 +212,4 @@ class ObservrClient:
             attrs["agent.model"] = model
         if tool is not None:
             attrs["agent.tool"] = tool
-        attrs.update(extra_attributes)
         return self.span(name, parent_span_id=parent_span_id, **attrs)

--- a/sdk/python/observr/_client.py
+++ b/sdk/python/observr/_client.py
@@ -183,3 +183,34 @@ class ObservrClient:
         """Context manager for manual spans."""
         from observr._span import Span
         return Span(name=name, transport=self._transport, attributes=attributes, parent_span_id=parent_span_id)
+
+    def agent_span(
+        self,
+        name: str,
+        *,
+        intent: str | None = None,
+        trigger: str | None = None,
+        model: str | None = None,
+        tool: str | None = None,
+        parent_span_id: str | None = None,
+        **extra_attributes: object,
+    ):
+        """Context manager for agent action spans with standard attribute keys.
+
+        Standard keys (omitted when None):
+            agent.intent   — goal the agent is working toward
+            agent.trigger  — what caused this action (user_message | tool_result | <span_id>)
+            agent.model    — LLM that made the decision
+            agent.tool     — tool being invoked
+        """
+        attrs: dict[str, object] = {}
+        if intent is not None:
+            attrs["agent.intent"] = intent
+        if trigger is not None:
+            attrs["agent.trigger"] = trigger
+        if model is not None:
+            attrs["agent.model"] = model
+        if tool is not None:
+            attrs["agent.tool"] = tool
+        attrs.update(extra_attributes)
+        return self.span(name, parent_span_id=parent_span_id, **attrs)

--- a/sdk/python/tests/test_agent_span.py
+++ b/sdk/python/tests/test_agent_span.py
@@ -1,0 +1,116 @@
+"""Tests for agent_span() — standard agent observability attribute helper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from observr._span import _active_span
+
+
+@pytest.fixture(autouse=True)
+def reset_context():
+    token = _active_span.set(None)
+    yield
+    _active_span.reset(token)
+
+
+@pytest.fixture()
+def client():
+    from observr._client import ObservrClient
+    c = ObservrClient(
+        service="test",
+        collector_url="http://localhost:7676",
+        auto_instrument=False,
+        log_level="debug",
+    )
+    c._transport = MagicMock()
+    c._transport.send = MagicMock()
+    return c
+
+
+def emitted(client) -> dict:
+    return client._transport.send.call_args[0][0]
+
+
+# ── Standard attributes ───────────────────────────────────────────────────────
+
+def test_agent_span_sets_intent(client):
+    with client.agent_span("decide", intent="summarize document"):
+        pass
+    assert emitted(client)["attributes"]["agent.intent"] == "summarize document"
+
+
+def test_agent_span_sets_trigger(client):
+    with client.agent_span("decide", trigger="user_message"):
+        pass
+    assert emitted(client)["attributes"]["agent.trigger"] == "user_message"
+
+
+def test_agent_span_sets_model(client):
+    with client.agent_span("decide", model="claude-sonnet-4-6"):
+        pass
+    assert emitted(client)["attributes"]["agent.model"] == "claude-sonnet-4-6"
+
+
+def test_agent_span_sets_tool(client):
+    with client.agent_span("tool.call", tool="web_search"):
+        pass
+    assert emitted(client)["attributes"]["agent.tool"] == "web_search"
+
+
+def test_agent_span_all_attributes(client):
+    with client.agent_span(
+        "tool.call",
+        intent="find papers",
+        trigger="user_message",
+        model="claude-sonnet-4-6",
+        tool="web_search",
+    ):
+        pass
+    attrs = emitted(client)["attributes"]
+    assert attrs["agent.intent"] == "find papers"
+    assert attrs["agent.trigger"] == "user_message"
+    assert attrs["agent.model"] == "claude-sonnet-4-6"
+    assert attrs["agent.tool"] == "web_search"
+
+
+def test_agent_span_omits_none_attributes(client):
+    with client.agent_span("decide", intent="summarize"):
+        pass
+    attrs = emitted(client)["attributes"]
+    assert "agent.trigger" not in attrs
+    assert "agent.model" not in attrs
+    assert "agent.tool" not in attrs
+
+
+# ── Extra attributes pass through ────────────────────────────────────────────
+
+def test_agent_span_forwards_extra_kwargs(client):
+    with client.agent_span("decide", intent="summarize", result_count=5):
+        pass
+    attrs = emitted(client)["attributes"]
+    assert attrs["result_count"] == 5
+    assert attrs["agent.intent"] == "summarize"
+
+
+# ── Context propagation works the same as span() ─────────────────────────────
+
+def test_agent_span_inherits_parent_context(client):
+    with client.span("outer") as outer:
+        with client.agent_span("inner", intent="sub-task") as inner:
+            assert inner.parent_span_id == outer.span_id
+            assert inner.trace_id == outer.trace_id
+
+
+def test_agent_span_explicit_parent_id(client):
+    with client.agent_span("child", intent="sub-task", parent_span_id="explicit-id") as span:
+        assert span.parent_span_id == "explicit-id"
+
+
+def test_agent_span_emits_span_type(client):
+    with client.agent_span("decide", intent="summarize"):
+        pass
+    assert emitted(client)["type"] == "span"
+    assert emitted(client)["message"] == "decide"

--- a/sdk/python/tests/test_agent_span.py
+++ b/sdk/python/tests/test_agent_span.py
@@ -95,6 +95,14 @@ def test_agent_span_forwards_extra_kwargs(client):
     assert attrs["agent.intent"] == "summarize"
 
 
+# ── Standard keys take priority over extra kwargs ────────────────────────────
+
+def test_standard_keys_override_extra_kwargs(client):
+    with client.agent_span("decide", intent="correct", **{"agent.intent": "should-be-overridden"}):
+        pass
+    assert emitted(client)["attributes"]["agent.intent"] == "correct"
+
+
 # ── Context propagation works the same as span() ─────────────────────────────
 
 def test_agent_span_inherits_parent_context(client):


### PR DESCRIPTION
## Summary

Closes #19

Adds `agent_span()` (Python) and `agentSpan()` (Node.js) — thin wrappers over the existing `span()` API that pre-populate standard attribute keys for AI agent observability.

**Standard attribute keys:**

| Key | Type | Description |
|-----|------|-------------|
| `agent.intent` | string | Goal the agent is working toward |
| `agent.trigger` | string | What caused this action (`user_message`, `tool_result`, span ID) |
| `agent.model` | string | LLM that made the decision |
| `agent.tool` | string | Tool being invoked |

All keys are optional — only provided values are set. Extra kwargs pass through to the underlying span.

Context propagation (automatic `parent_span_id` / `trace_id` threading) works identically to `span()`.

## Changes

- `sdk/python/observr/_client.py` — `agent_span()` method on `ObservrClient`
- `sdk/node/src/client.ts` — `agentSpan()` method on `ObservrClient`
- `AGENTS.md` — agent attribute convention documented with usage examples
- `sdk/python/tests/test_agent_span.py` — 10 unit tests
- `sdk/node/tests/agent-span.test.ts` — 9 unit tests

## Test plan

- [ ] Python unit tests: `cd sdk/python && python -m pytest tests/test_agent_span.py -v`
- [ ] Node.js unit tests: `cd sdk/node && npm test`
- [ ] Full test suites pass: `make test`
- [ ] Real integration test: collector running, spans stored with correct `agent.*` attributes and causal chain verified via `/query` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Python 및 Node.js SDK에 에이전트 스팬(agent span) 기능 추가

* **동작 개선 / 속성**
  * 에이전트 관찰성 속성(agent.intent, agent.trigger, agent.model, agent.tool) 지원 — None/미지정 속성은 전송되지 않음
  * 추가 임의 속성은 그대로 전달되며 표준 키가 우선 덮어씀
  * span 중첩 시 parent/span/trace 컨텍스트를 자동 상속(명시적 parent 지정 가능)

* **문서**
  * 에이전트 속성 규칙 및 사용 예시 추가

* **테스트**
  * Python 및 Node.js용 에이전트 스팬 동작 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->