### PR TITLE
feat(dashboard): causality tree view for agent decision chains (#20)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import { FilterBar, type Filters } from "./components/FilterBar";
 import { EventTable } from "./components/EventTable";
 import { PatternCard } from "./components/PatternCard";
 import { StatusDot } from "./components/StatusDot";
+import { TracePanel } from "./components/TracePanel";
 import type { Level, ObservrEvent } from "./types";
 
 function computeStats(events: ObservrEvent[]) {
@@ -89,6 +90,7 @@ export default function App() {
   const { events, connected, clear } = useEventStream();
   const [filters, setFilters] = useState<Filters>({ level: "", search: "" });
   const [activeTab, setActiveTab] = useState<Tab>("events");
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
 
   // Patterns tab state
   const [patternSince, setPatternSince] = useState("15m");
@@ -230,7 +232,7 @@ export default function App() {
 
             {/* Table */}
             <div style={{ flex: 1, padding: "0 var(--space-8) var(--space-8)" }}>
-              <EventTable events={filtered} />
+              <EventTable events={filtered} onSelectTrace={setSelectedTraceId} />
             </div>
           </>
         )}
@@ -346,6 +348,10 @@ export default function App() {
           </>
         )}
       </main>
+
+      {selectedTraceId && (
+        <TracePanel traceId={selectedTraceId} onClose={() => setSelectedTraceId(null)} />
+      )}
     </div>
   );
 }

--- a/dashboard/src/components/EventTable.tsx
+++ b/dashboard/src/components/EventTable.tsx
@@ -5,6 +5,7 @@ import { EventDetail } from "./EventDetail";
 
 interface Props {
   events: ObservrEvent[];
+  onSelectTrace?: (traceId: string) => void;
 }
 
 function formatTime(iso: string): string {
@@ -29,7 +30,7 @@ function getMethodColor(method?: string): string {
   }
 }
 
-export function EventTable({ events }: Props) {
+export function EventTable({ events, onSelectTrace }: Props) {
   const [selected, setSelected] = useState<ObservrEvent | null>(null);
 
   if (events.length === 0) {
@@ -91,6 +92,7 @@ export function EventTable({ events }: Props) {
                 index={i}
                 selected={selected?.id === evt.id}
                 onClick={() => setSelected(selected?.id === evt.id ? null : evt)}
+                onSelectTrace={onSelectTrace}
                 getMethodColor={getMethodColor}
                 formatTime={formatTime}
                 formatDuration={formatDuration}
@@ -112,12 +114,13 @@ interface RowProps {
   index: number;
   selected: boolean;
   onClick: () => void;
+  onSelectTrace?: (traceId: string) => void;
   getMethodColor: (m?: string) => string;
   formatTime: (s: string) => string;
   formatDuration: (ms?: number) => string;
 }
 
-function EventRow({ event: evt, index, selected, onClick, getMethodColor, formatTime, formatDuration }: RowProps) {
+function EventRow({ event: evt, index, selected, onClick, onSelectTrace, getMethodColor, formatTime, formatDuration }: RowProps) {
   const isError = evt.level === "error";
   const statusOk = evt.status_code && evt.status_code < 400;
 
@@ -209,6 +212,29 @@ function EventRow({ event: evt, index, selected, onClick, getMethodColor, format
           >
             {evt.message}
           </span>
+        )}
+        {evt.trace_id && onSelectTrace && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onSelectTrace(evt.trace_id!); }}
+            style={{
+              marginTop: 2,
+              display: "inline-block",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              lineHeight: "16px",
+              padding: "0 5px",
+              borderRadius: 4,
+              background: "var(--accent-subtle)",
+              color: "var(--accent)",
+              border: "1px solid oklch(55% 0.18 250 / 0.25)",
+              cursor: "pointer",
+              fontWeight: 500,
+              letterSpacing: "0.02em",
+            }}
+            title={`View trace ${evt.trace_id}`}
+          >
+            ⎇ {evt.trace_id.slice(0, 8)}
+          </button>
         )}
       </td>
 

--- a/dashboard/src/components/EventTable.tsx
+++ b/dashboard/src/components/EventTable.tsx
@@ -216,6 +216,7 @@ function EventRow({ event: evt, index, selected, onClick, onSelectTrace, getMeth
         {evt.trace_id && onSelectTrace && (
           <button
             onClick={(e) => { e.stopPropagation(); onSelectTrace(evt.trace_id!); }}
+            aria-label={`View trace ${evt.trace_id}`}
             style={{
               marginTop: 2,
               display: "inline-block",

--- a/dashboard/src/components/TracePanel.tsx
+++ b/dashboard/src/components/TracePanel.tsx
@@ -1,0 +1,343 @@
+import type { ObservrEvent } from "../types";
+import { useTraceEvents } from "../hooks/useTraceEvents";
+
+interface Props {
+  traceId: string;
+  onClose: () => void;
+}
+
+interface TreeNode {
+  event: ObservrEvent;
+  children: TreeNode[];
+  depth: number;
+}
+
+function buildTree(events: ObservrEvent[]): TreeNode[] {
+  const bySpanId = new Map<string, TreeNode>();
+
+  for (const evt of events) {
+    bySpanId.set(evt.span_id ?? evt.id, { event: evt, children: [], depth: 0 });
+  }
+
+  const roots: TreeNode[] = [];
+  for (const [, node] of bySpanId) {
+    const parentKey = node.event.parent_span_id;
+    if (parentKey && bySpanId.has(parentKey)) {
+      bySpanId.get(parentKey)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  function setDepth(node: TreeNode, d: number) {
+    node.depth = d;
+    node.children.sort((a, b) => a.event.timestamp.localeCompare(b.event.timestamp));
+    for (const child of node.children) setDepth(child, d + 1);
+  }
+  roots.sort((a, b) => a.event.timestamp.localeCompare(b.event.timestamp));
+  roots.forEach((n) => setDepth(n, 0));
+
+  return roots;
+}
+
+function flatten(nodes: TreeNode[]): TreeNode[] {
+  const out: TreeNode[] = [];
+  for (const n of nodes) {
+    out.push(n);
+    out.push(...flatten(n.children));
+  }
+  return out;
+}
+
+const TYPE_ICON: Record<string, string> = {
+  span: "◎",
+  http_request: "⇄",
+  log: "·",
+};
+
+interface AgentChipStyle {
+  bg: string;
+  text: string;
+  border: string;
+}
+
+const AGENT_CHIP_STYLES: Record<string, AgentChipStyle> = {
+  "agent.intent":  { bg: "oklch(55% 0.18 250 / 0.10)", text: "oklch(40% 0.20 250)", border: "oklch(55% 0.18 250 / 0.35)" },
+  "agent.trigger": { bg: "oklch(55% 0.18 290 / 0.10)", text: "oklch(40% 0.20 290)", border: "oklch(55% 0.18 290 / 0.35)" },
+  "agent.model":   { bg: "oklch(50% 0.15 170 / 0.10)", text: "oklch(35% 0.15 170)", border: "oklch(50% 0.15 170 / 0.35)" },
+  "agent.tool":    { bg: "oklch(55% 0.18 45 / 0.10)",  text: "oklch(40% 0.18 45)",  border: "oklch(55% 0.18 45 / 0.35)"  },
+};
+
+function getAgentAttrs(event: ObservrEvent): Array<{ key: string; label: string; value: string }> {
+  if (!event.attributes) return [];
+  return Object.keys(AGENT_CHIP_STYLES)
+    .filter((k) => event.attributes![k] !== undefined)
+    .map((k) => ({ key: k, label: k.replace("agent.", ""), value: String(event.attributes![k]) }));
+}
+
+export function TracePanel({ traceId, onClose }: Props) {
+  const { events, loading } = useTraceEvents(traceId);
+  const nodes = flatten(buildTree(events));
+
+  const times = events.map((e) => new Date(e.timestamp).getTime());
+  const traceStart = times.length ? Math.min(...times) : 0;
+  const traceEnd = Math.max(
+    ...events.map((e) => new Date(e.timestamp).getTime() + (e.duration_ms ?? 0)),
+    traceStart + 1
+  );
+  const traceDuration = traceEnd - traceStart;
+
+  return (
+    <div style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", justifyContent: "flex-end" }}>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: "oklch(18% 0.02 250 / 0.25)",
+          animation: "fadeIn var(--duration-base) var(--ease-out-quart)",
+        }}
+      />
+
+      {/* Panel */}
+      <aside
+        style={{
+          position: "relative",
+          width: "min(640px, 95vw)",
+          height: "100%",
+          background: "var(--bg-surface)",
+          borderLeft: "1px solid var(--border)",
+          boxShadow: "-4px 0 24px oklch(18% 0.02 250 / 0.10)",
+          overflowY: "auto",
+          animation: "slideInRight var(--duration-slow) var(--ease-out-quart)",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "var(--space-5) var(--space-6)",
+            borderBottom: "1px solid var(--border)",
+            position: "sticky",
+            top: 0,
+            background: "var(--bg-surface)",
+            zIndex: 1,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+            <span style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--text-primary)" }}>
+              Trace
+            </span>
+            <code
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "var(--text-xs)",
+                color: "var(--text-secondary)",
+                background: "var(--bg-subtle)",
+                padding: "2px 6px",
+                borderRadius: 4,
+              }}
+            >
+              {traceId.slice(0, 8)}…
+            </code>
+            {!loading && (
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--text-tertiary)" }}>
+                {events.length} event{events.length !== 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "var(--text-tertiary)",
+              fontSize: "var(--text-lg)",
+              padding: "var(--space-1)",
+              lineHeight: 1,
+              borderRadius: "var(--radius-sm)",
+              transition: "color var(--duration-fast)",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-primary)")}
+            onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-tertiary)")}
+            aria-label="Close trace"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: "var(--space-3) var(--space-4)", flex: 1 }}>
+          {loading && (
+            <p style={{ color: "var(--text-tertiary)", fontSize: "var(--text-sm)", padding: "var(--space-4) 0" }}>
+              Loading…
+            </p>
+          )}
+
+          {!loading && events.length === 0 && (
+            <p style={{ color: "var(--text-tertiary)", fontSize: "var(--text-sm)", padding: "var(--space-4) 0" }}>
+              No events found for this trace.
+            </p>
+          )}
+
+          {!loading &&
+            nodes.map((node, i) => {
+              const { event, depth } = node;
+              const startMs = new Date(event.timestamp).getTime() - traceStart;
+              const barOffset = (startMs / traceDuration) * 100;
+              const barWidth = Math.max(((event.duration_ms ?? 0) / traceDuration) * 100, 0.8);
+              const icon = TYPE_ICON[event.type] ?? "·";
+              const isError = event.level === "error";
+              const agentAttrs = getAgentAttrs(event);
+              const barColor = isError
+                ? "var(--status-error)"
+                : event.type === "http_request"
+                  ? "var(--status-ok)"
+                  : "var(--accent)";
+
+              return (
+                <div
+                  key={event.id + i}
+                  style={{ borderBottom: "1px solid var(--border)", padding: "var(--space-2) 0" }}
+                >
+                  {/* Main row */}
+                  <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", minWidth: 0 }}>
+                    {/* Depth indent */}
+                    <div style={{ width: depth * 14, flexShrink: 0 }} />
+
+                    {/* Type icon */}
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "var(--text-xs)",
+                        color: isError ? "var(--status-error)" : "var(--text-tertiary)",
+                        flexShrink: 0,
+                        width: 14,
+                        textAlign: "center",
+                      }}
+                    >
+                      {icon}
+                    </span>
+
+                    {/* Message */}
+                    <span
+                      style={{
+                        flex: 1,
+                        fontSize: "var(--text-xs)",
+                        color: isError ? "var(--status-error)" : "var(--text-primary)",
+                        fontWeight: isError ? 500 : 400,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        fontFamily: event.type === "span" ? "var(--font-mono)" : "var(--font-sans)",
+                        minWidth: 0,
+                      }}
+                      title={event.message}
+                    >
+                      {event.message}
+                    </span>
+
+                    {/* Duration label */}
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "var(--text-xs)",
+                        color: "var(--text-tertiary)",
+                        flexShrink: 0,
+                        width: 52,
+                        textAlign: "right",
+                      }}
+                    >
+                      {event.duration_ms != null ? `${Math.round(event.duration_ms)}ms` : ""}
+                    </span>
+
+                    {/* Waterfall bar */}
+                    <div
+                      style={{
+                        width: 140,
+                        flexShrink: 0,
+                        height: 8,
+                        background: "var(--bg-subtle)",
+                        borderRadius: 3,
+                        position: "relative",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: `${barOffset}%`,
+                          width: `${barWidth}%`,
+                          height: "100%",
+                          borderRadius: 3,
+                          background: barColor,
+                          opacity: 0.7,
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Agent attribute badges */}
+                  {agentAttrs.length > 0 && (
+                    <div
+                      style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "var(--space-1)",
+                        paddingTop: "var(--space-1)",
+                        paddingLeft: depth * 14 + 28,
+                      }}
+                    >
+                      {agentAttrs.map(({ key, label, value }) => {
+                        const s = AGENT_CHIP_STYLES[key];
+                        return (
+                          <span
+                            key={key}
+                            title={`${key}: ${value}`}
+                            style={{
+                              fontSize: 10,
+                              lineHeight: "18px",
+                              padding: "0 6px",
+                              borderRadius: 10,
+                              background: s.bg,
+                              color: s.text,
+                              border: `1px solid ${s.border}`,
+                              fontWeight: 500,
+                              whiteSpace: "nowrap",
+                              maxWidth: 200,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              display: "inline-block",
+                            }}
+                          >
+                            {label}: {value}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      </aside>
+
+      <style>{`
+        @keyframes slideInRight {
+          from { transform: translateX(100%); }
+          to   { transform: translateX(0); }
+        }
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to   { opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/TracePanel.tsx
+++ b/dashboard/src/components/TracePanel.tsx
@@ -79,13 +79,12 @@ export function TracePanel({ traceId, onClose }: Props) {
   const { events, loading } = useTraceEvents(traceId);
   const nodes = flatten(buildTree(events));
 
-  const times = events.map((e) => new Date(e.timestamp).getTime());
-  const traceStart = times.length ? Math.min(...times) : 0;
-  const traceEnd = Math.max(
-    ...events.map((e) => new Date(e.timestamp).getTime() + (e.duration_ms ?? 0)),
-    traceStart + 1
-  );
-  const traceDuration = traceEnd - traceStart;
+  // SDKs emit timestamp at span completion; start = timestamp - duration_ms, end = timestamp.
+  const spanStart = (e: ObservrEvent) => new Date(e.timestamp).getTime() - (e.duration_ms ?? 0);
+  const spanEnd   = (e: ObservrEvent) => new Date(e.timestamp).getTime();
+  const traceStart = events.length ? Math.min(...events.map(spanStart)) : 0;
+  const traceEnd   = events.length ? Math.max(...events.map(spanEnd), traceStart + 1) : 1;
+  const traceDuration = Math.max(traceEnd - traceStart, 1);
 
   return (
     <div style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", justifyContent: "flex-end" }}>
@@ -189,8 +188,7 @@ export function TracePanel({ traceId, onClose }: Props) {
           {!loading &&
             nodes.map((node, i) => {
               const { event, depth } = node;
-              const startMs = new Date(event.timestamp).getTime() - traceStart;
-              const barOffset = (startMs / traceDuration) * 100;
+              const barOffset = ((spanStart(event) - traceStart) / traceDuration) * 100;
               const barWidth = Math.max(((event.duration_ms ?? 0) / traceDuration) * 100, 0.8);
               const icon = TYPE_ICON[event.type] ?? "·";
               const isError = event.level === "error";

--- a/dashboard/src/hooks/useTraceEvents.ts
+++ b/dashboard/src/hooks/useTraceEvents.ts
@@ -8,15 +8,18 @@ export function useTraceEvents(traceId: string | null) {
   useEffect(() => {
     if (!traceId) {
       setEvents([]);
+      setLoading(false);
       return;
     }
+    const controller = new AbortController();
     setLoading(true);
     const params = new URLSearchParams({ trace_id: traceId, last: "1000", format: "json" });
-    fetch(`/query?${params}`)
+    fetch(`/query?${params}`, { signal: controller.signal })
       .then((r) => (r.ok ? r.json() : []))
       .then((data: ObservrEvent[]) => setEvents(Array.isArray(data) ? data : []))
-      .catch(() => setEvents([]))
+      .catch((err) => { if (err.name !== "AbortError") setEvents([]); })
       .finally(() => setLoading(false));
+    return () => controller.abort();
   }, [traceId]);
 
   return { events, loading };

--- a/dashboard/src/hooks/useTraceEvents.ts
+++ b/dashboard/src/hooks/useTraceEvents.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import type { ObservrEvent } from "../types";
+
+export function useTraceEvents(traceId: string | null) {
+  const [events, setEvents] = useState<ObservrEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!traceId) {
+      setEvents([]);
+      return;
+    }
+    setLoading(true);
+    const params = new URLSearchParams({ trace_id: traceId, last: "1000", format: "json" });
+    fetch(`/query?${params}`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: ObservrEvent[]) => setEvents(Array.isArray(data) ? data : []))
+      .catch(() => setEvents([]))
+      .finally(() => setLoading(false));
+  }, [traceId]);
+
+  return { events, loading };
+}

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -5,6 +5,7 @@ export interface ObservrEvent {
   id: string;
   trace_id?: string;
   span_id?: string;
+  parent_span_id?: string;
   service: string;
   timestamp: string;
   type: EventType;


### PR DESCRIPTION
## Summary

- Adds **TracePanel** — a right-side drawer that opens when clicking the trace chip on any event row, showing all spans in the trace as a waterfall/tree
- Adds **`useTraceEvents` hook** — fetches `/query?trace_id=...` to load the full causal chain for a trace
- Adds `parent_span_id` to the `ObservrEvent` TypeScript type (was already stored in SQLite and returned by the query API)
- Adds a clickable **`⎇ <trace_id>` chip** in each event row that has a `trace_id`, opening the TracePanel on click
- TracePanel displays agent attribute badges per span (`agent.intent`, `agent.trigger`, `agent.model`, `agent.tool`) with color-coded chips

## How it works

The tree is built from `parent_span_id` → `span_id` links. Spans are sorted by timestamp and rendered in DFS order (parent first, then children). Waterfall bars show each span's start offset and duration relative to the total trace duration.

## Test plan

- [x] Python SDK integration test: created a 4-span causal chain (`agent.run` → `tool.call(web_search)` → `tool.call(parse_json)`, `agent.decide`); verified `/query?trace_id=...` returns correct parent-child structure
- [x] Dashboard UI test (Playwright): trace chip renders in all rows with a `trace_id`; clicking opens TracePanel with correct waterfall order, waterfall bars, and agent attribute badges
- [x] TypeScript build: `tsc && vite build` passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트 테이블에서 트레이스를 선택해 별도 패널로 상세 타임라인을 확인할 수 있습니다.
  * 트레이스는 계층적 타임라인(워터폴)으로 표시되어 각 작업의 지속 시간과 관계를 파악할 수 있습니다.
  * 에러 레벨 이벤트는 강조되어 문제를 빠르게 식별할 수 있습니다.
  * 트레이스 로딩/빈 상태 메시지와 패널 닫기 기능이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->