### PR TITLE
docs: update README, architecture, and CLAUDE.md for agent_span and trace view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,12 +61,13 @@ cd server && go vet ./...
   - `shutdown()` restores `builtins.__import__` to its original value.
 - **FastAPI instrumentation**: patches `fastapi.FastAPI.__init__` to call `app.add_middleware(ObservrMiddleware, ...)` on every new app instance.
 - **Transport**: background thread, 10k event queue, silent drop, 1s flush interval, POSTs JSON to `/events`.
+- **Span API**: `client.span(name, parent_span_id=None, **attrs)` — context manager, propagates via `ContextVar`. `client.agent_span(name, *, intent, trigger, model, tool, **extra)` — thin wrapper that pre-populates standard agent attribute keys; standard keys take priority over `**extra`.
 - **Zero dependencies**: `sdk/python/pyproject.toml` has `dependencies = []`. Flask, FastAPI, Django are optional extras.
 
 ### Node.js SDK (`sdk/node/`)
 
 - **Transport**: uses `fetch()` (Node 18+ built-in), `AbortSignal.timeout(3000)`, background `setInterval`. Timer is `.unref()`'d so the process can exit normally.
-- **Span API**: `client.span("name").run(async (s) => { ... })` — async, emits on completion.
+- **Span API**: `client.span(name, attrs).run(async (s) => { ... })` — async, emits on completion. `client.agentSpan(name, { intent?, trigger?, model?, tool?, ...extra })` — same contract as Python's `agent_span()`; destructures standard keys, passes remainder as arbitrary attributes.
 - **Console patch**: replaces `console.log/debug/warn/error` with wrapped versions that send log events. Restored by `unpatchConsole()`.
 - **Build**: `tsup` outputs both ESM and CJS with `.d.ts` declarations.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,30 +69,33 @@ observr는 이 질문들에 답하는 도구입니다.
 <details>
 <summary><strong>인과 귀속 — 모든 결과를 근본 원인까지 역추적</strong></summary>
 
-모든 span은 자신을 트리거한 부모 행동을 가리키는 `parent_span_id`를 가질 수 있습니다. observr는 이를 바탕으로 전체 결정 트리를 재구성합니다.
+모든 span은 `parent_span_id`로 트리거한 부모 행동을 연결합니다. `agent_span()` / `agentSpan()`을 사용하면 표준 관찰 속성(`intent`, `trigger`, `model`, `tool`)을 자동으로 기록하고, 중첩 시 인과 체인이 자동으로 이어집니다.
 
 ```python
-with observr.get_client().span("agent.decide") as parent:
-    with observr.get_client().span("tool.call", parent_span_id=parent.span_id, tool="web_search") as child:
+# Python — 중첩 시 parent_span_id 자동 전파
+client = observr.get_client()
+with client.agent_span("agent.decide", intent="사용자 질문 답변", model="claude-sonnet-4-6") as root:
+    with client.agent_span("tool.call", trigger=root.span_id, tool="web_search") as child:
         results = web_search("relevant context")
         child.set_attribute("result_count", len(results))
 ```
 
 ```
 trace_id: 4f2a1b3c
-├── agent.decide   (a1b2)
-│   ├── tool.call  (c3d4, parent: a1b2)  ← agent.decide가 트리거
-│   └── db.query   (g7h8, parent: a1b2)
+├── agent.decide   (a1b2)  intent="사용자 질문 답변"  model="claude-sonnet-4-6"
+│   └── tool.call  (c3d4, parent: a1b2)  tool="web_search"  result_count=12
 ```
 
 ```ts
 // Node.js
-const parent = new Span("agent.decide", transport);
-await parent.run(async (p) => {
-  const child = new Span("tool.call", transport, { tool: "web_search" }, p.spanId);
-  await child.run(async () => { /* 인과적으로 연결됨 */ });
-});
+await client.agentSpan("agent.decide", { intent: "사용자 질문 답변", model: "claude-sonnet-4-6" })
+  .run(async (root) => {
+    await client.agentSpan("tool.call", { trigger: root.spanId, tool: "web_search" })
+      .run(async () => { /* parent_span_id 자동 설정 */ });
+  });
 ```
+
+대시보드의 **trace 칩**을 클릭하면 인과 트리가 열립니다 — 모든 span의 실행 시간, 에이전트 속성을 waterfall로 시각화합니다.
 
 </details>
 
@@ -157,11 +160,12 @@ const { init } = require('@ydking0911/observr')
 init({ service: 'my-agent' })
 ```
 
-**에이전트 행동 단위로 수동 span:**
+**에이전트 span — 표준 속성으로 인과 체인 기록:**
 ```python
-with observr.get_client().span("db.query", table="users") as span:
-    rows = db.execute("SELECT ...")
-    span.set_attribute("row_count", len(rows))
+client = observr.get_client()
+with client.agent_span("tool.call", intent="최신 논문 검색", tool="web_search") as span:
+    results = web_search("observability 2026")
+    span.set_attribute("result_count", len(results))
 ```
 
 **로그는 자동으로 수집됩니다:**
@@ -252,8 +256,9 @@ observrd start \
 | **v0.2** | ✅ | Node.js SDK · PyPI 배포 · npm 배포 |
 | **v0.3** | ✅ | Slack/Discord 알림 · 이벤트 보존 정책(TTL) · JSON/CSV 내보내기 |
 | **v0.4** | ✅ | 인과 귀속 (`parent_span_id`) · 행동 패턴 감지 · Fastify 지원 |
-| **v0.5** | 📋 | 감사 리포트 생성 · 인과 체인 내보내기 · 멀티 에이전트 트레이싱 |
-| **v0.6** | 📋 | Go SDK · 정책 규칙 엔진 · 온체인 앵커링 |
+| **v0.5** | 🚧 | `agent_span()` / `agentSpan()` 헬퍼 · 대시보드 인과 트리 뷰 · Django 지원 |
+| **v0.6** | 📋 | 감사 리포트 생성 · 인과 체인 내보내기 (JSON-LD) · 정책 규칙 엔진 |
+| **v0.7** | 📋 | Go SDK · 온체인 앵커링 · 멀티 에이전트 트레이싱 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -69,30 +69,33 @@ observr answers these questions.
 <details>
 <summary><strong>Causal Attribution — trace any outcome back to its root</strong></summary>
 
-Every span can carry a `parent_span_id` that links it to the action that triggered it. observr reconstructs the full decision tree.
+Every span carries a `parent_span_id` that links it to the action that triggered it. Use `agent_span()` / `agentSpan()` to attach standard observability keys (`intent`, `trigger`, `model`, `tool`) — nesting automatically threads the causal chain.
 
 ```python
-with observr.get_client().span("agent.decide") as parent:
-    with observr.get_client().span("tool.call", parent_span_id=parent.span_id, tool="web_search") as child:
+# Python — context propagation is automatic when spans are nested
+client = observr.get_client()
+with client.agent_span("agent.decide", intent="answer user", model="claude-sonnet-4-6") as root:
+    with client.agent_span("tool.call", trigger=root.span_id, tool="web_search") as child:
         results = web_search("relevant context")
         child.set_attribute("result_count", len(results))
 ```
 
 ```
 trace_id: 4f2a1b3c
-├── agent.decide   (a1b2)
-│   ├── tool.call  (c3d4, parent: a1b2)  ← triggered by agent.decide
-│   └── db.query   (g7h8, parent: a1b2)
+├── agent.decide   (a1b2)  intent="answer user"  model="claude-sonnet-4-6"
+│   └── tool.call  (c3d4, parent: a1b2)  tool="web_search"  result_count=12
 ```
 
 ```ts
 // Node.js
-const parent = new Span("agent.decide", transport);
-await parent.run(async (p) => {
-  const child = new Span("tool.call", transport, { tool: "web_search" }, p.spanId);
-  await child.run(async () => { /* causally linked */ });
-});
+await client.agentSpan("agent.decide", { intent: "answer user", model: "claude-sonnet-4-6" })
+  .run(async (root) => {
+    await client.agentSpan("tool.call", { trigger: root.spanId, tool: "web_search" })
+      .run(async () => { /* causally linked — parent_span_id set automatically */ });
+  });
 ```
+
+Click any **trace chip** in the dashboard to open the causality tree — a waterfall showing every span, its duration, and agent attributes.
 
 </details>
 
@@ -157,11 +160,12 @@ const { init } = require('@ydking0911/observr')
 init({ service: 'my-agent' })
 ```
 
-**Manual spans for agent actions:**
+**Agent spans — causal chain with standard attribute keys:**
 ```python
-with observr.get_client().span("db.query", table="users") as span:
-    rows = db.execute("SELECT ...")
-    span.set_attribute("row_count", len(rows))
+client = observr.get_client()
+with client.agent_span("tool.call", intent="find recent papers", tool="web_search") as span:
+    results = web_search("observability 2026")
+    span.set_attribute("result_count", len(results))
 ```
 
 **Logs are captured automatically:**
@@ -252,8 +256,9 @@ observrd start \
 | **v0.2** | ✅ | Node.js SDK · PyPI publish · npm publish |
 | **v0.3** | ✅ | Slack/Discord alerts · Event retention (TTL) · JSON/CSV export |
 | **v0.4** | ✅ | Causal attribution (`parent_span_id`) · Behavioral pattern detection · Fastify support |
-| **v0.5** | 📋 | Audit report generation · Causal chain export · Multi-agent tracing |
-| **v0.6** | 📋 | Go SDK · Policy rule engine · On-chain anchoring |
+| **v0.5** | 🚧 | `agent_span()` / `agentSpan()` helper · Dashboard causality tree view · Django support |
+| **v0.6** | 📋 | Audit report generation · Causal chain export (JSON-LD) · Policy rule engine |
+| **v0.7** | 📋 | Go SDK · On-chain anchoring · Multi-agent tracing |
 
 ---
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import { FilterBar, type Filters } from "./components/FilterBar";
 import { EventTable } from "./components/EventTable";
 import { PatternCard } from "./components/PatternCard";
 import { StatusDot } from "./components/StatusDot";
+import { TracePanel } from "./components/TracePanel";
 import type { Level, ObservrEvent } from "./types";
 
 function computeStats(events: ObservrEvent[]) {
@@ -89,6 +90,7 @@ export default function App() {
   const { events, connected, clear } = useEventStream();
   const [filters, setFilters] = useState<Filters>({ level: "", search: "" });
   const [activeTab, setActiveTab] = useState<Tab>("events");
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
 
   // Patterns tab state
   const [patternSince, setPatternSince] = useState("15m");
@@ -230,7 +232,7 @@ export default function App() {
 
             {/* Table */}
             <div style={{ flex: 1, padding: "0 var(--space-8) var(--space-8)" }}>
-              <EventTable events={filtered} />
+              <EventTable events={filtered} onSelectTrace={setSelectedTraceId} />
             </div>
           </>
         )}
@@ -346,6 +348,10 @@ export default function App() {
           </>
         )}
       </main>
+
+      {selectedTraceId && (
+        <TracePanel traceId={selectedTraceId} onClose={() => setSelectedTraceId(null)} />
+      )}
     </div>
   );
 }

--- a/dashboard/src/components/EventTable.tsx
+++ b/dashboard/src/components/EventTable.tsx
@@ -5,6 +5,7 @@ import { EventDetail } from "./EventDetail";
 
 interface Props {
   events: ObservrEvent[];
+  onSelectTrace?: (traceId: string) => void;
 }
 
 function formatTime(iso: string): string {
@@ -29,7 +30,7 @@ function getMethodColor(method?: string): string {
   }
 }
 
-export function EventTable({ events }: Props) {
+export function EventTable({ events, onSelectTrace }: Props) {
   const [selected, setSelected] = useState<ObservrEvent | null>(null);
 
   if (events.length === 0) {
@@ -91,6 +92,7 @@ export function EventTable({ events }: Props) {
                 index={i}
                 selected={selected?.id === evt.id}
                 onClick={() => setSelected(selected?.id === evt.id ? null : evt)}
+                onSelectTrace={onSelectTrace}
                 getMethodColor={getMethodColor}
                 formatTime={formatTime}
                 formatDuration={formatDuration}
@@ -112,12 +114,13 @@ interface RowProps {
   index: number;
   selected: boolean;
   onClick: () => void;
+  onSelectTrace?: (traceId: string) => void;
   getMethodColor: (m?: string) => string;
   formatTime: (s: string) => string;
   formatDuration: (ms?: number) => string;
 }
 
-function EventRow({ event: evt, index, selected, onClick, getMethodColor, formatTime, formatDuration }: RowProps) {
+function EventRow({ event: evt, index, selected, onClick, onSelectTrace, getMethodColor, formatTime, formatDuration }: RowProps) {
   const isError = evt.level === "error";
   const statusOk = evt.status_code && evt.status_code < 400;
 
@@ -209,6 +212,29 @@ function EventRow({ event: evt, index, selected, onClick, getMethodColor, format
           >
             {evt.message}
           </span>
+        )}
+        {evt.trace_id && onSelectTrace && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onSelectTrace(evt.trace_id!); }}
+            style={{
+              marginTop: 2,
+              display: "inline-block",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              lineHeight: "16px",
+              padding: "0 5px",
+              borderRadius: 4,
+              background: "var(--accent-subtle)",
+              color: "var(--accent)",
+              border: "1px solid oklch(55% 0.18 250 / 0.25)",
+              cursor: "pointer",
+              fontWeight: 500,
+              letterSpacing: "0.02em",
+            }}
+            title={`View trace ${evt.trace_id}`}
+          >
+            ⎇ {evt.trace_id.slice(0, 8)}
+          </button>
         )}
       </td>
 

--- a/dashboard/src/components/EventTable.tsx
+++ b/dashboard/src/components/EventTable.tsx
@@ -216,6 +216,7 @@ function EventRow({ event: evt, index, selected, onClick, onSelectTrace, getMeth
         {evt.trace_id && onSelectTrace && (
           <button
             onClick={(e) => { e.stopPropagation(); onSelectTrace(evt.trace_id!); }}
+            aria-label={`View trace ${evt.trace_id}`}
             style={{
               marginTop: 2,
               display: "inline-block",

--- a/dashboard/src/components/TracePanel.tsx
+++ b/dashboard/src/components/TracePanel.tsx
@@ -1,0 +1,343 @@
+import type { ObservrEvent } from "../types";
+import { useTraceEvents } from "../hooks/useTraceEvents";
+
+interface Props {
+  traceId: string;
+  onClose: () => void;
+}
+
+interface TreeNode {
+  event: ObservrEvent;
+  children: TreeNode[];
+  depth: number;
+}
+
+function buildTree(events: ObservrEvent[]): TreeNode[] {
+  const bySpanId = new Map<string, TreeNode>();
+
+  for (const evt of events) {
+    bySpanId.set(evt.span_id ?? evt.id, { event: evt, children: [], depth: 0 });
+  }
+
+  const roots: TreeNode[] = [];
+  for (const [, node] of bySpanId) {
+    const parentKey = node.event.parent_span_id;
+    if (parentKey && bySpanId.has(parentKey)) {
+      bySpanId.get(parentKey)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  function setDepth(node: TreeNode, d: number) {
+    node.depth = d;
+    node.children.sort((a, b) => a.event.timestamp.localeCompare(b.event.timestamp));
+    for (const child of node.children) setDepth(child, d + 1);
+  }
+  roots.sort((a, b) => a.event.timestamp.localeCompare(b.event.timestamp));
+  roots.forEach((n) => setDepth(n, 0));
+
+  return roots;
+}
+
+function flatten(nodes: TreeNode[]): TreeNode[] {
+  const out: TreeNode[] = [];
+  for (const n of nodes) {
+    out.push(n);
+    out.push(...flatten(n.children));
+  }
+  return out;
+}
+
+const TYPE_ICON: Record<string, string> = {
+  span: "◎",
+  http_request: "⇄",
+  log: "·",
+};
+
+interface AgentChipStyle {
+  bg: string;
+  text: string;
+  border: string;
+}
+
+const AGENT_CHIP_STYLES: Record<string, AgentChipStyle> = {
+  "agent.intent":  { bg: "oklch(55% 0.18 250 / 0.10)", text: "oklch(40% 0.20 250)", border: "oklch(55% 0.18 250 / 0.35)" },
+  "agent.trigger": { bg: "oklch(55% 0.18 290 / 0.10)", text: "oklch(40% 0.20 290)", border: "oklch(55% 0.18 290 / 0.35)" },
+  "agent.model":   { bg: "oklch(50% 0.15 170 / 0.10)", text: "oklch(35% 0.15 170)", border: "oklch(50% 0.15 170 / 0.35)" },
+  "agent.tool":    { bg: "oklch(55% 0.18 45 / 0.10)",  text: "oklch(40% 0.18 45)",  border: "oklch(55% 0.18 45 / 0.35)"  },
+};
+
+function getAgentAttrs(event: ObservrEvent): Array<{ key: string; label: string; value: string }> {
+  if (!event.attributes) return [];
+  return Object.keys(AGENT_CHIP_STYLES)
+    .filter((k) => event.attributes![k] !== undefined)
+    .map((k) => ({ key: k, label: k.replace("agent.", ""), value: String(event.attributes![k]) }));
+}
+
+export function TracePanel({ traceId, onClose }: Props) {
+  const { events, loading } = useTraceEvents(traceId);
+  const nodes = flatten(buildTree(events));
+
+  const times = events.map((e) => new Date(e.timestamp).getTime());
+  const traceStart = times.length ? Math.min(...times) : 0;
+  const traceEnd = Math.max(
+    ...events.map((e) => new Date(e.timestamp).getTime() + (e.duration_ms ?? 0)),
+    traceStart + 1
+  );
+  const traceDuration = traceEnd - traceStart;
+
+  return (
+    <div style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", justifyContent: "flex-end" }}>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: "oklch(18% 0.02 250 / 0.25)",
+          animation: "fadeIn var(--duration-base) var(--ease-out-quart)",
+        }}
+      />
+
+      {/* Panel */}
+      <aside
+        style={{
+          position: "relative",
+          width: "min(640px, 95vw)",
+          height: "100%",
+          background: "var(--bg-surface)",
+          borderLeft: "1px solid var(--border)",
+          boxShadow: "-4px 0 24px oklch(18% 0.02 250 / 0.10)",
+          overflowY: "auto",
+          animation: "slideInRight var(--duration-slow) var(--ease-out-quart)",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "var(--space-5) var(--space-6)",
+            borderBottom: "1px solid var(--border)",
+            position: "sticky",
+            top: 0,
+            background: "var(--bg-surface)",
+            zIndex: 1,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+            <span style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--text-primary)" }}>
+              Trace
+            </span>
+            <code
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "var(--text-xs)",
+                color: "var(--text-secondary)",
+                background: "var(--bg-subtle)",
+                padding: "2px 6px",
+                borderRadius: 4,
+              }}
+            >
+              {traceId.slice(0, 8)}…
+            </code>
+            {!loading && (
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--text-tertiary)" }}>
+                {events.length} event{events.length !== 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "var(--text-tertiary)",
+              fontSize: "var(--text-lg)",
+              padding: "var(--space-1)",
+              lineHeight: 1,
+              borderRadius: "var(--radius-sm)",
+              transition: "color var(--duration-fast)",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-primary)")}
+            onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-tertiary)")}
+            aria-label="Close trace"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: "var(--space-3) var(--space-4)", flex: 1 }}>
+          {loading && (
+            <p style={{ color: "var(--text-tertiary)", fontSize: "var(--text-sm)", padding: "var(--space-4) 0" }}>
+              Loading…
+            </p>
+          )}
+
+          {!loading && events.length === 0 && (
+            <p style={{ color: "var(--text-tertiary)", fontSize: "var(--text-sm)", padding: "var(--space-4) 0" }}>
+              No events found for this trace.
+            </p>
+          )}
+
+          {!loading &&
+            nodes.map((node, i) => {
+              const { event, depth } = node;
+              const startMs = new Date(event.timestamp).getTime() - traceStart;
+              const barOffset = (startMs / traceDuration) * 100;
+              const barWidth = Math.max(((event.duration_ms ?? 0) / traceDuration) * 100, 0.8);
+              const icon = TYPE_ICON[event.type] ?? "·";
+              const isError = event.level === "error";
+              const agentAttrs = getAgentAttrs(event);
+              const barColor = isError
+                ? "var(--status-error)"
+                : event.type === "http_request"
+                  ? "var(--status-ok)"
+                  : "var(--accent)";
+
+              return (
+                <div
+                  key={event.id + i}
+                  style={{ borderBottom: "1px solid var(--border)", padding: "var(--space-2) 0" }}
+                >
+                  {/* Main row */}
+                  <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", minWidth: 0 }}>
+                    {/* Depth indent */}
+                    <div style={{ width: depth * 14, flexShrink: 0 }} />
+
+                    {/* Type icon */}
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "var(--text-xs)",
+                        color: isError ? "var(--status-error)" : "var(--text-tertiary)",
+                        flexShrink: 0,
+                        width: 14,
+                        textAlign: "center",
+                      }}
+                    >
+                      {icon}
+                    </span>
+
+                    {/* Message */}
+                    <span
+                      style={{
+                        flex: 1,
+                        fontSize: "var(--text-xs)",
+                        color: isError ? "var(--status-error)" : "var(--text-primary)",
+                        fontWeight: isError ? 500 : 400,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        fontFamily: event.type === "span" ? "var(--font-mono)" : "var(--font-sans)",
+                        minWidth: 0,
+                      }}
+                      title={event.message}
+                    >
+                      {event.message}
+                    </span>
+
+                    {/* Duration label */}
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "var(--text-xs)",
+                        color: "var(--text-tertiary)",
+                        flexShrink: 0,
+                        width: 52,
+                        textAlign: "right",
+                      }}
+                    >
+                      {event.duration_ms != null ? `${Math.round(event.duration_ms)}ms` : ""}
+                    </span>
+
+                    {/* Waterfall bar */}
+                    <div
+                      style={{
+                        width: 140,
+                        flexShrink: 0,
+                        height: 8,
+                        background: "var(--bg-subtle)",
+                        borderRadius: 3,
+                        position: "relative",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: `${barOffset}%`,
+                          width: `${barWidth}%`,
+                          height: "100%",
+                          borderRadius: 3,
+                          background: barColor,
+                          opacity: 0.7,
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Agent attribute badges */}
+                  {agentAttrs.length > 0 && (
+                    <div
+                      style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "var(--space-1)",
+                        paddingTop: "var(--space-1)",
+                        paddingLeft: depth * 14 + 28,
+                      }}
+                    >
+                      {agentAttrs.map(({ key, label, value }) => {
+                        const s = AGENT_CHIP_STYLES[key];
+                        return (
+                          <span
+                            key={key}
+                            title={`${key}: ${value}`}
+                            style={{
+                              fontSize: 10,
+                              lineHeight: "18px",
+                              padding: "0 6px",
+                              borderRadius: 10,
+                              background: s.bg,
+                              color: s.text,
+                              border: `1px solid ${s.border}`,
+                              fontWeight: 500,
+                              whiteSpace: "nowrap",
+                              maxWidth: 200,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              display: "inline-block",
+                            }}
+                          >
+                            {label}: {value}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      </aside>
+
+      <style>{`
+        @keyframes slideInRight {
+          from { transform: translateX(100%); }
+          to   { transform: translateX(0); }
+        }
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to   { opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/TracePanel.tsx
+++ b/dashboard/src/components/TracePanel.tsx
@@ -79,13 +79,12 @@ export function TracePanel({ traceId, onClose }: Props) {
   const { events, loading } = useTraceEvents(traceId);
   const nodes = flatten(buildTree(events));
 
-  const times = events.map((e) => new Date(e.timestamp).getTime());
-  const traceStart = times.length ? Math.min(...times) : 0;
-  const traceEnd = Math.max(
-    ...events.map((e) => new Date(e.timestamp).getTime() + (e.duration_ms ?? 0)),
-    traceStart + 1
-  );
-  const traceDuration = traceEnd - traceStart;
+  // SDKs emit timestamp at span completion; start = timestamp - duration_ms, end = timestamp.
+  const spanStart = (e: ObservrEvent) => new Date(e.timestamp).getTime() - (e.duration_ms ?? 0);
+  const spanEnd   = (e: ObservrEvent) => new Date(e.timestamp).getTime();
+  const traceStart = events.length ? Math.min(...events.map(spanStart)) : 0;
+  const traceEnd   = events.length ? Math.max(...events.map(spanEnd), traceStart + 1) : 1;
+  const traceDuration = Math.max(traceEnd - traceStart, 1);
 
   return (
     <div style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", justifyContent: "flex-end" }}>
@@ -189,8 +188,7 @@ export function TracePanel({ traceId, onClose }: Props) {
           {!loading &&
             nodes.map((node, i) => {
               const { event, depth } = node;
-              const startMs = new Date(event.timestamp).getTime() - traceStart;
-              const barOffset = (startMs / traceDuration) * 100;
+              const barOffset = ((spanStart(event) - traceStart) / traceDuration) * 100;
               const barWidth = Math.max(((event.duration_ms ?? 0) / traceDuration) * 100, 0.8);
               const icon = TYPE_ICON[event.type] ?? "·";
               const isError = event.level === "error";

--- a/dashboard/src/hooks/useTraceEvents.ts
+++ b/dashboard/src/hooks/useTraceEvents.ts
@@ -8,15 +8,18 @@ export function useTraceEvents(traceId: string | null) {
   useEffect(() => {
     if (!traceId) {
       setEvents([]);
+      setLoading(false);
       return;
     }
+    const controller = new AbortController();
     setLoading(true);
     const params = new URLSearchParams({ trace_id: traceId, last: "1000", format: "json" });
-    fetch(`/query?${params}`)
+    fetch(`/query?${params}`, { signal: controller.signal })
       .then((r) => (r.ok ? r.json() : []))
       .then((data: ObservrEvent[]) => setEvents(Array.isArray(data) ? data : []))
-      .catch(() => setEvents([]))
+      .catch((err) => { if (err.name !== "AbortError") setEvents([]); })
       .finally(() => setLoading(false));
+    return () => controller.abort();
   }, [traceId]);
 
   return { events, loading };

--- a/dashboard/src/hooks/useTraceEvents.ts
+++ b/dashboard/src/hooks/useTraceEvents.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import type { ObservrEvent } from "../types";
+
+export function useTraceEvents(traceId: string | null) {
+  const [events, setEvents] = useState<ObservrEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!traceId) {
+      setEvents([]);
+      return;
+    }
+    setLoading(true);
+    const params = new URLSearchParams({ trace_id: traceId, last: "1000", format: "json" });
+    fetch(`/query?${params}`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: ObservrEvent[]) => setEvents(Array.isArray(data) ? data : []))
+      .catch(() => setEvents([]))
+      .finally(() => setLoading(false));
+  }, [traceId]);
+
+  return { events, loading };
+}

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -5,6 +5,7 @@ export interface ObservrEvent {
   id: string;
   trace_id?: string;
   span_id?: string;
+  parent_span_id?: string;
   service: string;
   timestamp: string;
   type: EventType;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,15 +96,17 @@ Query the full tree: `observrd query --trace-id 4f2a1b3c --format json`
 ```
 sdk/python/observr/
 ├── __init__.py          init(), get_client()
-├── _client.py           ObservrClient — lazy import hook, lifecycle, framework dispatch
+├── _client.py           ObservrClient — lazy import hook, lifecycle, span(), agent_span()
 ├── _transport.py        Background thread, 10k queue, HTTP batch POST
 ├── _logger.py           logging.Handler — captures all log records
-├── _span.py             Manual span context manager; carries parent_span_id
+├── _span.py             Manual span context manager; carries parent_span_id via ContextVar
 └── integrations/
     ├── flask.py         before_request / after_request hooks
     ├── fastapi.py       ASGI middleware, monkey-patches FastAPI.__init__
     └── django.py        WSGI middleware
 ```
+
+`agent_span(name, *, intent, trigger, model, tool, **extra)` — thin wrapper over `span()` that pre-populates standard agent attribute keys. Keys are omitted when `None`; extra kwargs pass through as arbitrary attributes.
 
 ### SDK (Node.js)
 
@@ -113,10 +115,13 @@ sdk/node/src/
 ├── index.ts        Public API — init(), Span
 ├── transport.ts    fetch() + AbortSignal.timeout(3000), unref() timer
 ├── span.ts         Async span: new Span(name, transport, attrs, parentSpanId)
+├── client.ts       ObservrClient — span(), agentSpan()
 ├── logger.ts       console.log/warn/error patch
 └── integrations/
     └── express.ts  Express middleware
 ```
+
+`agentSpan(name, { intent?, trigger?, model?, tool?, ...extra })` — same contract as Python's `agent_span()`. Destructures standard keys, passes remainder as arbitrary attributes.
 
 ### Collector Server (Go)
 
@@ -211,18 +216,24 @@ CREATE TABLE events (
 
 ```
 dashboard/src/
-├── App.tsx               Layout, stats computation, filter state
-├── types.ts              ObservrEvent, Stats interfaces
+├── App.tsx               Layout, stats computation, filter + trace state
+├── types.ts              ObservrEvent (incl. parent_span_id), Stats, Pattern
 ├── hooks/
-│   └── useEventStream.ts WebSocket + HTTP initial load
+│   ├── useEventStream.ts WebSocket + HTTP initial load
+│   ├── usePatterns.ts    Polled pattern fetch (/patterns)
+│   └── useTraceEvents.ts Fetch all spans for a trace_id (/query?trace_id=…)
 └── components/
     ├── MetricCard.tsx     p50/p99/RPS/error count cards
-    ├── FilterBar.tsx      Level tabs + search input
-    ├── EventTable.tsx     Audit event list with click-to-expand
-    ├── EventDetail.tsx    Slide-in detail panel (shows causal chain)
+    ├── FilterBar.tsx      Level tabs + search input + export
+    ├── EventTable.tsx     Audit event list; trace chip opens TracePanel
+    ├── EventDetail.tsx    Slide-in detail panel (raw event attributes)
+    ├── TracePanel.tsx     Causality tree: waterfall + agent attribute badges
+    ├── PatternCard.tsx    Behavioral pattern summary card
     ├── LevelBadge.tsx     ERROR / WARN / INFO / DEBUG pill
     └── StatusDot.tsx      Live / Disconnected indicator
 ```
+
+**TracePanel** builds a tree from `parent_span_id → span_id` links and renders a waterfall: each span's bar starts at `timestamp - duration_ms` (SDK emits at completion) and is proportional to the trace total duration. Agent attribute badges (`intent`, `trigger`, `model`, `tool`) appear below each span row.
 
 ---
 
@@ -241,9 +252,11 @@ dashboard/src/
 
 ---
 
-## Roadmap: Planned Audit Features
+## Roadmap: Audit Features
 
-| Version | Features |
-|---------|----------|
-| **v0.5** | Audit report generation · Accountability chain export (full trace tree as JSON) · Multi-agent tracing |
-| **v0.6** | Compliance export (EU AI Act / SOC2) · Policy rule engine · On-chain anchoring (`blockchain.Anchorer` via `Broadcaster`) |
+| Version | Status | Features |
+|---------|:------:|----------|
+| **v0.4** | ✅ | Causal attribution (`parent_span_id`) · Behavioral pattern detection · Django / Fastify support |
+| **v0.5** | 🚧 | `agent_span()` / `agentSpan()` helper · Dashboard causality tree view (TracePanel waterfall) |
+| **v0.6** | 📋 | Audit report generation · Accountability chain export (full trace tree as JSON-LD) · Policy rule engine |
+| **v0.7** | 📋 | Compliance export (EU AI Act / SOC2) · On-chain anchoring (`blockchain.Anchorer` via `Broadcaster`) · Go SDK |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대시보드에 트레이스 시각화 패널 추가 - 이벤트에서 트레이스를 선택하면 스팬 계층 구조를 워터폴 타임라인 형식으로 표시
  * 에이전트 스팬 헬퍼 API 지원 - 표준 속성 자동 기록 및 인과 관계 체인 자동 연결

* **문서**
  * Python/Node.js SDK 가이드 업데이트 - `agent_span()` / `agentSpan()` 사용 방식으로 변경
  * 제품 로드맵 재정렬 - v0.5~v0.7 기능 배치 재구성

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->