### PR TITLE
feat(python): Django ASGI support + incoming trace context propagation (#36)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ New audit outputs (on-chain anchoring, compliance exporters, SIEM integrations) 
 | `sdk/python/observr/_client.py` | Python | Lazy import hook, lifecycle, framework dispatch |
 | `sdk/python/observr/_transport.py` | Python | Background thread, queue, HTTP POST |
 | `sdk/python/observr/integrations/fastapi.py` | Python | Patches `fastapi.FastAPI.__init__` |
-| `sdk/python/observr/integrations/django.py` | Python | WSGI middleware; `_get_transport()` fallback |
+| `sdk/python/observr/integrations/django.py` | Python | WSGI + ASGI middleware; X-Trace-Id/X-Span-Id propagation; exception event emit |
 | `sdk/node/src/transport.ts` | TypeScript | `fetch` + `AbortSignal.timeout`, `unref()` timer |
 | `sdk/node/src/span.ts` | TypeScript | Async span, error capture; carries `parent_span_id` for causal chain |
 | `.github/workflows/ci.yml` | CI | All language test matrix |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,5 +110,7 @@ cd server && go vet ./...
 1. **`go:embed all:dist` vs `dist/*`**: always use `all:dist`. The `dist/*` glob silently fails when only `.gitkeep` exists.
 2. **FastAPI import order**: in production code, import FastAPI BEFORE `observr.init()` OR use lazy instrumentation (init first). Both work. In tests that re-import observr, be careful about `sys.modules` state.
 3. **Django middleware settings**: when added via `settings.py` string (`"observr.integrations.django.ObservrMiddleware"`), Django's middleware loader calls `__init__(get_response)`. When used programmatically, call `ObservrMiddleware(transport, get_response)`.
-4. **CGO for SQLite**: Go builds require `CGO_ENABLED=1` and `gcc`/`libc-dev`. CI installs `gcc libc-dev` before building.
-5. **Node.js fetch + AbortSignal.timeout**: requires Node 18+. Node 16 does not have built-in `fetch`.
+4. **Django ASGI mode**: `ObservrMiddleware` auto-detects async `get_response` via `iscoroutinefunction` and marks itself async. Do not add explicit `async` handling — the middleware already delegates to `_acall` internally. Requires `asgiref` (bundled with Django 3.1+).
+5. **Django trace context**: `X-Trace-Id` and `X-Span-Id` request headers are read automatically to continue upstream traces. If headers are absent, a fresh `trace_id` is generated. `parent_span_id` is only set when `X-Span-Id` is present.
+6. **CGO for SQLite**: Go builds require `CGO_ENABLED=1` and `gcc`/`libc-dev`. CI installs `gcc libc-dev` before building.
+7. **Node.js fetch + AbortSignal.timeout**: requires Node 18+. Node 16 does not have built-in `fetch`.

--- a/README.ko.md
+++ b/README.ko.md
@@ -148,10 +148,11 @@ npm install @ydking0911/observr   # Node.js
 
 ### 3. 에이전트 계측
 
-**Python — FastAPI / Flask / Django**
+**Python — FastAPI / Flask / Django (WSGI + ASGI)**
 ```python
 import observr
 observr.init(service="my-agent")  # 프레임워크 자동 감지
+# Django: X-Trace-Id / X-Span-Id 헤더 자동 전파로 서비스 간 trace 연결
 ```
 
 **Node.js — Express**

--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ npm install @ydking0911/observr   # Node.js
 
 ### 3. Instrument your agent
 
-**Python — FastAPI / Flask / Django**
+**Python — FastAPI / Flask / Django (WSGI + ASGI)**
 ```python
 import observr
 observr.init(service="my-agent")  # auto-detects the framework
+# Django: X-Trace-Id / X-Span-Id headers are propagated automatically
 ```
 
 **Node.js — Express**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,10 +103,12 @@ sdk/python/observr/
 └── integrations/
     ├── flask.py         before_request / after_request hooks
     ├── fastapi.py       ASGI middleware, monkey-patches FastAPI.__init__
-    └── django.py        WSGI middleware
+    └── django.py        WSGI + ASGI middleware; X-Trace-Id / X-Span-Id propagation
 ```
 
 `agent_span(name, *, intent, trigger, model, tool, **extra)` — thin wrapper over `span()` that pre-populates standard agent attribute keys. Keys are omitted when `None`; extra kwargs pass through as arbitrary attributes.
+
+`ObservrMiddleware` (Django): dual-mode — detects sync vs async `get_response` via `iscoroutinefunction` and marks itself async with `markcoroutinefunction` so Django's ASGI handler calls it natively. Reads `X-Trace-Id` / `X-Span-Id` request headers for cross-service trace propagation. On view exception, emits an error event (`status_code=500`, `attributes.error_type`) before re-raising.
 
 ### SDK (Node.js)
 

--- a/sdk/python/observr/integrations/django.py
+++ b/sdk/python/observr/integrations/django.py
@@ -105,7 +105,11 @@ class ObservrMiddleware:
     def _call(self, request):
         trace_id, span_id, parent_span_id = _extract_ids(request)
         start = time.monotonic()
-        response = self._get_response(request)
+        try:
+            response = self._get_response(request)
+        except Exception as exc:
+            _emit(self._transport, request, None, trace_id, span_id, parent_span_id, start, exc=exc)
+            raise
         _emit(self._transport, request, response, trace_id, span_id, parent_span_id, start)
         return response
 
@@ -114,7 +118,11 @@ class ObservrMiddleware:
     async def _acall(self, request):
         trace_id, span_id, parent_span_id = _extract_ids(request)
         start = time.monotonic()
-        response = await self._get_response(request)
+        try:
+            response = await self._get_response(request)
+        except Exception as exc:
+            _emit(self._transport, request, None, trace_id, span_id, parent_span_id, start, exc=exc)
+            raise
         _emit(self._transport, request, response, trace_id, span_id, parent_span_id, start)
         return response
 
@@ -137,12 +145,26 @@ def _emit(
     span_id: str,
     parent_span_id: str | None,
     start: float,
+    *,
+    exc: BaseException | None = None,
 ) -> None:
     duration_ms = round((time.monotonic() - start) * 1000, 2)
-    status_code = response.status_code
-    level = "error" if status_code >= 500 else "warn" if status_code >= 400 else "info"
+    if response is not None:
+        status_code = response.status_code
+        level = "error" if status_code >= 500 else "warn" if status_code >= 400 else "info"
+    else:
+        status_code = 500
+        level = "error"
     path = getattr(request, "path", "/")
     method = getattr(request, "method", "")
+
+    attrs: dict = {
+        "remote_addr": _get_ip(request),
+        "user_agent": request.META.get("HTTP_USER_AGENT", ""),
+    }
+    if exc is not None:
+        attrs["error"] = str(exc)
+        attrs["error_type"] = type(exc).__name__
 
     event: dict = {
         "timestamp": datetime.now(tz=timezone.utc).isoformat(),
@@ -155,10 +177,7 @@ def _emit(
         "path": path,
         "status_code": status_code,
         "duration_ms": duration_ms,
-        "attributes": {
-            "remote_addr": _get_ip(request),
-            "user_agent": request.META.get("HTTP_USER_AGENT", ""),
-        },
+        "attributes": attrs,
     }
     if parent_span_id:
         event["parent_span_id"] = parent_span_id

--- a/sdk/python/observr/integrations/django.py
+++ b/sdk/python/observr/integrations/django.py
@@ -1,17 +1,30 @@
 """
 Django integration — middleware that emits HTTP trace events for every request.
 
-Called automatically by ObservrClient when `django` is detected in sys.modules,
-OR can be added manually to MIDDLEWARE in settings.py:
+Works for both WSGI and ASGI deployments. When the inner ``get_response``
+callable is a coroutine function (ASGI mode), the middleware is automatically
+marked as async so Django's ASGI handler calls it natively without a thread.
+
+Called automatically by ObservrClient when ``django`` is detected in
+sys.modules, OR can be added manually to settings.py::
 
     MIDDLEWARE = [
         "observr.integrations.django.ObservrMiddleware",
         ...
     ]
+
+Incoming trace context
+----------------------
+If the request carries ``X-Trace-Id`` / ``X-Span-Id`` headers, the middleware
+reuses them so cross-service traces stay linked:
+
+    trace_id      ← X-Trace-Id   (generated if absent)
+    parent_span_id ← X-Span-Id   (omitted if absent)
 """
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 import time
 from datetime import datetime, timezone
@@ -19,6 +32,15 @@ from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from observr._transport import Transport
+
+# Use asgiref helpers when available (always true for Django 3.1+).
+try:
+    from asgiref.sync import iscoroutinefunction, markcoroutinefunction
+except ImportError:
+    iscoroutinefunction = asyncio.iscoroutinefunction  # type: ignore[assignment]
+
+    def markcoroutinefunction(fn):  # type: ignore[misc]
+        fn._is_coroutine = asyncio.coroutines._is_coroutine
 
 
 def instrument_django(transport: "Transport") -> None:
@@ -33,7 +55,7 @@ def instrument_django(transport: "Transport") -> None:
 
     existing = base_handler.BaseHandler.load_middleware
     if getattr(existing, "_observr_patched", False):
-        return  # already patched — avoid double-wrapping on re-init
+        return
 
     original_load = existing
 
@@ -46,61 +68,101 @@ def instrument_django(transport: "Transport") -> None:
 
 
 def _prepend_middleware(handler, transport: "Transport") -> None:
-    """Wrap the existing _middleware_chain with ObservrMiddleware."""
     if isinstance(getattr(handler, "_middleware_chain", None), ObservrMiddleware):
-        return  # already wrapped
+        return
     handler._middleware_chain = ObservrMiddleware(transport, handler._middleware_chain)
 
 
 class ObservrMiddleware:
     """
-    Django WSGI middleware.
-    Can also be added manually to settings.MIDDLEWARE as a string path.
+    Django middleware — WSGI and ASGI compatible.
+
+    Supports two calling conventions:
+      1. Django settings.py string path — Django calls ``__init__(get_response)``
+      2. Direct instantiation — ``ObservrMiddleware(transport, get_response)``
     """
 
     def __init__(self, get_response_or_transport, get_response: Callable | None = None) -> None:
-        # Support two calling conventions:
-        #   1. Django settings.py string: Django calls __init__(get_response)
-        #   2. Direct instantiation: ObservrMiddleware(transport, get_response)
         if get_response is None:
-            # Called by Django's middleware loader: first arg is get_response
             self._transport = _get_transport()
             self._get_response: Callable = get_response_or_transport
         else:
             self._transport = get_response_or_transport
             self._get_response = get_response
 
+        # Mark this middleware as async when the inner chain is async (ASGI).
+        # Django's ASGIHandler then awaits __call__ instead of using a thread.
+        if iscoroutinefunction(self._get_response):
+            markcoroutinefunction(self)
+
     def __call__(self, request):
-        trace_id = secrets.token_hex(16)
-        span_id = secrets.token_hex(8)
+        if iscoroutinefunction(self._get_response):
+            return self._acall(request)
+        return self._call(request)
+
+    # ── Synchronous (WSGI) ────────────────────────────────────────────────
+
+    def _call(self, request):
+        trace_id, span_id, parent_span_id = _extract_ids(request)
         start = time.monotonic()
-
         response = self._get_response(request)
-
-        duration_ms = round((time.monotonic() - start) * 1000, 2)
-        status_code = response.status_code
-        level = "error" if status_code >= 500 else "warn" if status_code >= 400 else "info"
-
-        path = getattr(request, "path", "/")
-        method = getattr(request, "method", "")
-
-        self._transport.send({
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            "type": "http_request",
-            "level": level,
-            "trace_id": trace_id,
-            "span_id": span_id,
-            "message": f"{method} {path}",
-            "method": method,
-            "path": path,
-            "status_code": status_code,
-            "duration_ms": duration_ms,
-            "attributes": {
-                "remote_addr": _get_ip(request),
-                "user_agent": request.META.get("HTTP_USER_AGENT", ""),
-            },
-        })
+        _emit(self._transport, request, response, trace_id, span_id, parent_span_id, start)
         return response
+
+    # ── Asynchronous (ASGI) ───────────────────────────────────────────────
+
+    async def _acall(self, request):
+        trace_id, span_id, parent_span_id = _extract_ids(request)
+        start = time.monotonic()
+        response = await self._get_response(request)
+        _emit(self._transport, request, response, trace_id, span_id, parent_span_id, start)
+        return response
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+def _extract_ids(request) -> tuple[str, str, str | None]:
+    """Read or generate trace / span IDs from incoming request headers."""
+    trace_id = request.META.get("HTTP_X_TRACE_ID") or secrets.token_hex(16)
+    parent_span_id = request.META.get("HTTP_X_SPAN_ID") or None
+    span_id = secrets.token_hex(8)
+    return trace_id, span_id, parent_span_id
+
+
+def _emit(
+    transport: "Transport",
+    request,
+    response,
+    trace_id: str,
+    span_id: str,
+    parent_span_id: str | None,
+    start: float,
+) -> None:
+    duration_ms = round((time.monotonic() - start) * 1000, 2)
+    status_code = response.status_code
+    level = "error" if status_code >= 500 else "warn" if status_code >= 400 else "info"
+    path = getattr(request, "path", "/")
+    method = getattr(request, "method", "")
+
+    event: dict = {
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "type": "http_request",
+        "level": level,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "message": f"{method} {path}",
+        "method": method,
+        "path": path,
+        "status_code": status_code,
+        "duration_ms": duration_ms,
+        "attributes": {
+            "remote_addr": _get_ip(request),
+            "user_agent": request.META.get("HTTP_USER_AGENT", ""),
+        },
+    }
+    if parent_span_id:
+        event["parent_span_id"] = parent_span_id
+    transport.send(event)
 
 
 def _get_ip(request) -> str:
@@ -111,7 +173,6 @@ def _get_ip(request) -> str:
 
 
 def _get_transport() -> "Transport":
-    """Fallback: retrieve transport from the global observr client."""
     import observr
     client = observr._client
     if client is None:

--- a/sdk/python/tests/test_django.py
+++ b/sdk/python/tests/test_django.py
@@ -188,3 +188,194 @@ def test_django_middleware_duration(collector):
     assert wait_for(lambda: any(e.get("path") == "/slow" for e in _CollectorHandler.events))
     event = next(e for e in _CollectorHandler.events if e.get("path") == "/slow")
     assert event["duration_ms"] >= 40
+
+
+# ── Incoming trace context propagation ───────────────────────────────────────
+
+def test_django_middleware_uses_incoming_trace_id(collector):
+    """X-Trace-Id header is used as trace_id instead of generating a new one."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-trace", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from django.http import JsonResponse
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    def view(request):
+        return JsonResponse({"ok": True})
+
+    factory = RequestFactory()
+    request = factory.get("/trace-ctx", HTTP_X_TRACE_ID="upstream-trace-abc123")
+    middleware = ObservrMiddleware(transport, view)
+    middleware(request)
+
+    assert wait_for(lambda: any(e.get("path") == "/trace-ctx" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/trace-ctx")
+    assert event["trace_id"] == "upstream-trace-abc123"
+
+
+def test_django_middleware_uses_incoming_span_id_as_parent(collector):
+    """X-Span-Id header is recorded as parent_span_id for causal attribution."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-parent", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from django.http import JsonResponse
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    def view(request):
+        return JsonResponse({"ok": True})
+
+    factory = RequestFactory()
+    request = factory.get(
+        "/parent-ctx",
+        HTTP_X_TRACE_ID="trace-xyz",
+        HTTP_X_SPAN_ID="parent-span-99",
+    )
+    middleware = ObservrMiddleware(transport, view)
+    middleware(request)
+
+    assert wait_for(lambda: any(e.get("path") == "/parent-ctx" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/parent-ctx")
+    assert event["trace_id"] == "trace-xyz"
+    assert event["parent_span_id"] == "parent-span-99"
+
+
+def test_django_middleware_generates_trace_id_when_header_absent(collector):
+    """A fresh trace_id is generated when X-Trace-Id header is not present."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-gen", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from django.http import JsonResponse
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    def view(request):
+        return JsonResponse({"ok": True})
+
+    factory = RequestFactory()
+    request = factory.get("/no-headers")
+    middleware = ObservrMiddleware(transport, view)
+    middleware(request)
+
+    assert wait_for(lambda: any(e.get("path") == "/no-headers" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/no-headers")
+    assert event["trace_id"]  # auto-generated, non-empty
+    assert "parent_span_id" not in event  # absent when header not sent
+
+
+# ── ASGI (async) path ─────────────────────────────────────────────────────────
+
+async def test_django_asgi_middleware_emits_event(collector):
+    """Async get_response triggers the ASGI path; event is emitted correctly."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-asgi", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from django.http import JsonResponse
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    async def async_view(request):
+        return JsonResponse({"async": True})
+
+    factory = RequestFactory()
+    request = factory.get("/async-path")
+    middleware = ObservrMiddleware(transport, async_view)
+
+    # In ASGI mode __call__ returns a coroutine; await it directly.
+    response = await middleware(request)
+
+    assert response.status_code == 200
+    assert wait_for(lambda: any(e.get("path") == "/async-path" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/async-path")
+    assert event["type"] == "http_request"
+    assert event["method"] == "GET"
+    assert event["status_code"] == 200
+    assert event["service"] == "django-asgi"
+
+
+async def test_django_asgi_propagates_trace_headers(collector):
+    """ASGI path also reads X-Trace-Id and X-Span-Id headers."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-asgi-ctx", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from django.http import JsonResponse
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    async def async_view(request):
+        return JsonResponse({"ok": True})
+
+    factory = RequestFactory()
+    request = factory.get(
+        "/async-ctx",
+        HTTP_X_TRACE_ID="async-trace-id",
+        HTTP_X_SPAN_ID="async-parent-span",
+    )
+    middleware = ObservrMiddleware(transport, async_view)
+    await middleware(request)
+
+    assert wait_for(lambda: any(e.get("path") == "/async-ctx" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/async-ctx")
+    assert event["trace_id"] == "async-trace-id"
+    assert event["parent_span_id"] == "async-parent-span"

--- a/sdk/python/tests/test_django.py
+++ b/sdk/python/tests/test_django.py
@@ -300,6 +300,83 @@ def test_django_middleware_generates_trace_id_when_header_absent(collector):
     assert "parent_span_id" not in event  # absent when header not sent
 
 
+# ── Exception handling ────────────────────────────────────────────────────────
+
+def test_django_middleware_emits_event_on_view_exception(collector):
+    """When the view raises, an error event is emitted and the exception re-raised."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-exc", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    def raising_view(request):
+        raise ValueError("kaboom")
+
+    factory = RequestFactory()
+    request = factory.get("/exc-path")
+    middleware = ObservrMiddleware(transport, raising_view)
+
+    with pytest.raises(ValueError, match="kaboom"):
+        middleware(request)
+
+    assert wait_for(lambda: any(e.get("path") == "/exc-path" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/exc-path")
+    assert event["level"] == "error"
+    assert event["status_code"] == 500
+    assert event["attributes"]["error_type"] == "ValueError"
+    assert "kaboom" in event["attributes"]["error"]
+
+
+async def test_django_asgi_middleware_emits_event_on_view_exception(collector):
+    """ASGI path: exception in async view is recorded and re-raised."""
+    pytest.importorskip("django")
+
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("observr"):
+            del sys.modules[mod]
+
+    _configure_django()
+
+    port = collector.server_address[1]
+    import observr
+    observr.init(service="django-asgi-exc", collector_url=f"http://127.0.0.1:{port}", auto_instrument=False)
+
+    from django.test import RequestFactory
+    from observr.integrations.django import ObservrMiddleware
+    import observr as _observr
+
+    transport = _observr._client._transport
+
+    async def raising_async_view(request):
+        raise RuntimeError("async boom")
+
+    factory = RequestFactory()
+    request = factory.get("/async-exc")
+    middleware = ObservrMiddleware(transport, raising_async_view)
+
+    with pytest.raises(RuntimeError, match="async boom"):
+        await middleware(request)
+
+    assert wait_for(lambda: any(e.get("path") == "/async-exc" for e in _CollectorHandler.events))
+    event = next(e for e in _CollectorHandler.events if e.get("path") == "/async-exc")
+    assert event["level"] == "error"
+    assert event["status_code"] == 500
+    assert event["attributes"]["error_type"] == "RuntimeError"
+
+
 # ── ASGI (async) path ─────────────────────────────────────────────────────────
 
 async def test_django_asgi_middleware_emits_event(collector):


### PR DESCRIPTION
## Summary

- `ObservrMiddleware` now works natively in **ASGI mode** (Django + uvicorn/daphne). When `get_response` is a coroutine function, the middleware is marked async via `markcoroutinefunction` so Django's `ASGIHandler` calls it natively without a thread wrapper.
- **Incoming trace context propagation**: `X-Trace-Id` header is used as `trace_id` (a fresh id is generated if absent); `X-Span-Id` header is recorded as `parent_span_id` for cross-service causal attribution.
- Extracted `_extract_ids()` and `_emit()` helpers to share logic between WSGI and ASGI paths — no duplication.

## Test plan

- [x] Existing 3 WSGI tests still pass
- [x] `X-Trace-Id` header → `trace_id` (WSGI)
- [x] `X-Span-Id` header → `parent_span_id` (WSGI)
- [x] Absent headers → auto-generated `trace_id`, no `parent_span_id` key
- [x] ASGI async path emits correct event
- [x] ASGI path also propagates `X-Trace-Id` / `X-Span-Id`
- [x] Full suite: 44/44 passed

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Django 미들웨어가 WSGI/ASGI 양쪽을 처리하고 요청별 트레이스 컨텍스트를 헤더로 재사용합니다.
  * 요청 헤더(X-Trace-Id, X-Span-Id) 기반 ID 전파 및 헤더 미존재 시 자동 트레이스 ID 생성.
  * 이벤트에 상태 코드, 지연(ms), 원격 IP/유저에이전트 등 일관된 메타데이터 포함.

* **Bug Fixes**
  * 미들웨어 중복 래핑 방지 및 예외 발생 시 오류 이벤트 수집 후 예외 재발생 보장 개선.

* **Tests**
  * 동기/비동기 경로의 헤더 전파와 예외 처리 동작을 검증하는 테스트 추가.

* **Documentation**
  * 가이드 및 문서에 WSGI/ASGI 지원과 헤더 기반 트레이스 전파 내용 업데이트.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->