### PR TITLE
feat(go-sdk): zero-dependency Go SDK with span, agentSpan, and net/http middleware (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,23 @@ jobs:
           path: server/bin/observrd
           retention-days: 7
 
+  # ── Go SDK ────────────────────────────────────────────────────────────
+  go-sdk:
+    name: Go SDK
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Test Go SDK
+        working-directory: sdk/go
+        run: go test ./... -race -timeout 60s
+
   # ── Node.js SDK ───────────────────────────────────────────────────────
   node:
     name: Node.js SDK

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -54,7 +54,7 @@ func (c *ObservrClient) Span(ctx context.Context, name string, attrs map[string]
 	s := &Span{
 		TraceID:    traceID(parent),
 		SpanID:     newID(),
-		Attributes: attrs,
+		Attributes: copyAttrs(attrs),
 	}
 	if parent != nil {
 		s.ParentID = parent.SpanID
@@ -97,9 +97,22 @@ func (c *ObservrClient) AgentSpan(ctx context.Context, name string, opts AgentSp
 	return c.Span(ctx, name, attrs)
 }
 
+func copyAttrs(attrs map[string]any) map[string]any {
+	if attrs == nil {
+		return nil
+	}
+	cp := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		cp[k] = v
+	}
+	return cp
+}
+
 func newID() string {
 	b := make([]byte, 8)
-	_, _ = rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic("observr: crypto/rand unavailable: " + err.Error())
+	}
 	return hex.EncodeToString(b)
 }
 
@@ -108,6 +121,8 @@ func traceID(parent *Span) string {
 		return parent.TraceID
 	}
 	b := make([]byte, 16)
-	_, _ = rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic("observr: crypto/rand unavailable: " + err.Error())
+	}
 	return hex.EncodeToString(b)
 }

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,0 +1,113 @@
+package observr
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+)
+
+// Config holds client configuration.
+type Config struct {
+	Service      string
+	CollectorURL string
+}
+
+// AgentSpanOptions sets standard agent attributes on a span.
+type AgentSpanOptions struct {
+	Intent  string
+	Trigger string
+	Model   string
+	Tool    string
+}
+
+// ObservrClient sends events to an observrd collector.
+type ObservrClient struct {
+	cfg       Config
+	transport *Transport
+}
+
+// NewClient creates a client. Call Start() before using.
+func NewClient(cfg Config) *ObservrClient {
+	if cfg.CollectorURL == "" {
+		cfg.CollectorURL = "http://localhost:7676"
+	}
+	if cfg.Service == "" {
+		cfg.Service = "app"
+	}
+	return &ObservrClient{
+		cfg:       cfg,
+		transport: NewTransport(cfg.CollectorURL),
+	}
+}
+
+// Start begins background flushing.
+func (c *ObservrClient) Start() { c.transport.Start() }
+
+// Shutdown drains and stops the transport.
+func (c *ObservrClient) Shutdown() { c.transport.Shutdown() }
+
+// Span creates a child span derived from ctx, returns a new ctx and an end func.
+// Call end() when the work is done — it emits the event.
+func (c *ObservrClient) Span(ctx context.Context, name string, attrs map[string]any) (context.Context, func()) {
+	parent := SpanFromContext(ctx)
+	s := &Span{
+		TraceID:    traceID(parent),
+		SpanID:     newID(),
+		Attributes: attrs,
+	}
+	if parent != nil {
+		s.ParentID = parent.SpanID
+	}
+	ctx = ContextWithSpan(ctx, s)
+	start := time.Now()
+	end := func() {
+		event := map[string]any{
+			"service":        c.cfg.Service,
+			"type":           "span",
+			"level":          "info",
+			"message":        name,
+			"trace_id":       s.TraceID,
+			"span_id":        s.SpanID,
+			"parent_span_id": s.ParentID,
+			"duration_ms":    float64(time.Since(start).Milliseconds()),
+			"attributes":     s.Attributes,
+			"timestamp":      time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		c.transport.Enqueue(event)
+	}
+	return ctx, end
+}
+
+// AgentSpan creates a span with standard agent attributes pre-populated.
+func (c *ObservrClient) AgentSpan(ctx context.Context, name string, opts AgentSpanOptions) (context.Context, func()) {
+	attrs := map[string]any{}
+	if opts.Intent != "" {
+		attrs["observr.intent"] = opts.Intent
+	}
+	if opts.Trigger != "" {
+		attrs["observr.trigger"] = opts.Trigger
+	}
+	if opts.Model != "" {
+		attrs["observr.model"] = opts.Model
+	}
+	if opts.Tool != "" {
+		attrs["observr.tool"] = opts.Tool
+	}
+	return c.Span(ctx, name, attrs)
+}
+
+func newID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func traceID(parent *Span) string {
+	if parent != nil && parent.TraceID != "" {
+		return parent.TraceID
+	}
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,0 +1,82 @@
+package observr_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+)
+
+func TestClientSpanEmitsEvent(t *testing.T) {
+	received := make(chan map[string]any, 10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var events []map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&events)
+		for _, e := range events {
+			received <- e
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := observr.NewClient(observr.Config{Service: "svc", CollectorURL: srv.URL})
+	c.Start()
+
+	ctx, end := c.Span(context.Background(), "test-span", nil)
+	observr.SpanFromContext(ctx).SetAttribute("key", "val")
+	end()
+
+	select {
+	case e := <-received:
+		if e["type"] != "span" {
+			t.Fatalf("expected type=span, got %v", e["type"])
+		}
+		if e["message"] != "test-span" {
+			t.Fatalf("unexpected message: %v", e["message"])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout")
+	}
+	c.Shutdown()
+}
+
+func TestClientAgentSpanSetsAttrs(t *testing.T) {
+	received := make(chan map[string]any, 10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var events []map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&events)
+		for _, e := range events {
+			received <- e
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := observr.NewClient(observr.Config{Service: "svc", CollectorURL: srv.URL})
+	c.Start()
+
+	_, end := c.AgentSpan(context.Background(), "agent-op", observr.AgentSpanOptions{
+		Intent: "summarize",
+		Tool:   "search",
+		Model:  "gpt-4o",
+	})
+	end()
+
+	select {
+	case e := <-received:
+		attrs, _ := e["attributes"].(map[string]any)
+		if attrs["observr.intent"] != "summarize" {
+			t.Fatalf("intent not set: %v", attrs)
+		}
+		if attrs["observr.tool"] != "search" {
+			t.Fatalf("tool not set: %v", attrs)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout")
+	}
+	c.Shutdown()
+}

--- a/sdk/go/example/main.go
+++ b/sdk/go/example/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+)
+
+func main() {
+	observr.Init(observr.Config{Service: "example-agent"})
+	defer observr.GetClient().Shutdown()
+
+	ctx, end := observr.StartAgentSpan(context.Background(), "summarize-doc", observr.AgentSpanOptions{
+		Intent: "summarize",
+		Model:  "claude-3-5-sonnet",
+		Tool:   "read_file",
+	})
+	defer end()
+
+	_, endChild := observr.StartSpan(ctx, "read_file", map[string]any{"path": "/tmp/doc.txt"})
+	defer endChild()
+
+	log.Println("spans emitted to observrd")
+}

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/ydking0911/observr/sdk/go
+
+go 1.22

--- a/sdk/go/integrations/nethttp/middleware.go
+++ b/sdk/go/integrations/nethttp/middleware.go
@@ -6,7 +6,8 @@ import (
 	observr "github.com/ydking0911/observr/sdk/go"
 )
 
-// Middleware wraps an http.Handler to inject observr spans and emit http_request events.
+// Middleware wraps an http.Handler to inject an observr span into the request
+// context and propagate W3C traceparent headers for cross-service trace correlation.
 func Middleware(c *observr.ObservrClient) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -23,11 +24,11 @@ func Middleware(c *observr.ObservrClient) func(http.Handler) http.Handler {
 				"http.path":   r.URL.Path,
 			})
 			span := observr.SpanFromContext(ctx)
-
 			w.Header().Set("traceparent", observr.FormatTraceparent(span))
 
 			rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rw, r.WithContext(ctx))
+			span.SetAttribute("http.status_code", rw.status)
 			end()
 		})
 	}

--- a/sdk/go/integrations/nethttp/middleware.go
+++ b/sdk/go/integrations/nethttp/middleware.go
@@ -1,0 +1,44 @@
+package nethttp
+
+import (
+	"net/http"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+)
+
+// Middleware wraps an http.Handler to inject observr spans and emit http_request events.
+func Middleware(c *observr.ObservrClient) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			if tp := r.Header.Get("traceparent"); tp != "" {
+				if parent, err := observr.ParseTraceparent(tp); err == nil {
+					ctx = observr.ContextWithSpan(ctx, parent)
+				}
+			}
+
+			ctx, end := c.Span(ctx, r.Method+" "+r.URL.Path, map[string]any{
+				"http.method": r.Method,
+				"http.path":   r.URL.Path,
+			})
+			span := observr.SpanFromContext(ctx)
+
+			w.Header().Set("traceparent", observr.FormatTraceparent(span))
+
+			rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(rw, r.WithContext(ctx))
+			end()
+		})
+	}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}

--- a/sdk/go/integrations/nethttp/middleware_test.go
+++ b/sdk/go/integrations/nethttp/middleware_test.go
@@ -17,6 +17,7 @@ func TestMiddlewareInjectsSpan(t *testing.T) {
 	})
 
 	c := observr.NewClient(observr.Config{Service: "svc", CollectorURL: "http://localhost:9999"})
+	defer c.Shutdown()
 	mw := nethttp.Middleware(c)
 	srv := httptest.NewServer(mw(handler))
 	defer srv.Close()
@@ -43,6 +44,7 @@ func TestMiddlewareReadsTraceparent(t *testing.T) {
 	})
 
 	c := observr.NewClient(observr.Config{Service: "svc", CollectorURL: "http://localhost:9999"})
+	defer c.Shutdown()
 	mw := nethttp.Middleware(c)
 	srv := httptest.NewServer(mw(handler))
 	defer srv.Close()

--- a/sdk/go/integrations/nethttp/middleware_test.go
+++ b/sdk/go/integrations/nethttp/middleware_test.go
@@ -1,0 +1,59 @@
+package nethttp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+	nethttp "github.com/ydking0911/observr/sdk/go/integrations/nethttp"
+)
+
+func TestMiddlewareInjectsSpan(t *testing.T) {
+	var gotSpan *observr.Span
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSpan = observr.SpanFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	c := observr.NewClient(observr.Config{Service: "svc", CollectorURL: "http://localhost:9999"})
+	mw := nethttp.Middleware(c)
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if gotSpan == nil {
+		t.Fatal("expected span in handler context, got nil")
+	}
+	if gotSpan.TraceID == "" {
+		t.Fatal("expected non-empty trace_id")
+	}
+}
+
+func TestMiddlewareReadsTraceparent(t *testing.T) {
+	var gotSpan *observr.Span
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSpan = observr.SpanFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	c := observr.NewClient(observr.Config{Service: "svc", CollectorURL: "http://localhost:9999"})
+	mw := nethttp.Middleware(c)
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ping", nil)
+	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	client := &http.Client{}
+	resp, _ := client.Do(req)
+	resp.Body.Close()
+
+	if gotSpan == nil || gotSpan.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("expected trace_id from traceparent, got: %+v", gotSpan)
+	}
+}

--- a/sdk/go/integrations/nethttp/middleware_test.go
+++ b/sdk/go/integrations/nethttp/middleware_test.go
@@ -47,11 +47,16 @@ func TestMiddlewareReadsTraceparent(t *testing.T) {
 	srv := httptest.NewServer(mw(handler))
 	defer srv.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ping", nil)
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/ping", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
-	client := &http.Client{}
-	resp, _ := client.Do(req)
-	resp.Body.Close()
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
 
 	if gotSpan == nil || gotSpan.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
 		t.Fatalf("expected trace_id from traceparent, got: %+v", gotSpan)

--- a/sdk/go/observr.go
+++ b/sdk/go/observr.go
@@ -1,11 +1,23 @@
 package observr
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
-var _client *ObservrClient
+var (
+	_mu     sync.Mutex
+	_client *ObservrClient
+)
 
 // Init initialises the global client. Call once at startup.
+// If called again, the previous client is shut down first.
 func Init(cfg Config) *ObservrClient {
+	_mu.Lock()
+	defer _mu.Unlock()
+	if _client != nil {
+		_client.Shutdown()
+	}
 	_client = NewClient(cfg)
 	_client.Start()
 	return _client
@@ -13,6 +25,8 @@ func Init(cfg Config) *ObservrClient {
 
 // GetClient returns the global client. Panics if Init was not called.
 func GetClient() *ObservrClient {
+	_mu.Lock()
+	defer _mu.Unlock()
 	if _client == nil {
 		panic("observr.Init() must be called before GetClient()")
 	}

--- a/sdk/go/observr.go
+++ b/sdk/go/observr.go
@@ -1,0 +1,30 @@
+package observr
+
+import "context"
+
+var _client *ObservrClient
+
+// Init initialises the global client. Call once at startup.
+func Init(cfg Config) *ObservrClient {
+	_client = NewClient(cfg)
+	_client.Start()
+	return _client
+}
+
+// GetClient returns the global client. Panics if Init was not called.
+func GetClient() *ObservrClient {
+	if _client == nil {
+		panic("observr.Init() must be called before GetClient()")
+	}
+	return _client
+}
+
+// StartSpan is a convenience wrapper around GetClient().Span().
+func StartSpan(ctx context.Context, name string, attrs map[string]any) (context.Context, func()) {
+	return GetClient().Span(ctx, name, attrs)
+}
+
+// StartAgentSpan is a convenience wrapper around GetClient().AgentSpan().
+func StartAgentSpan(ctx context.Context, name string, opts AgentSpanOptions) (context.Context, func()) {
+	return GetClient().AgentSpan(ctx, name, opts)
+}

--- a/sdk/go/span.go
+++ b/sdk/go/span.go
@@ -1,0 +1,32 @@
+package observr
+
+import "context"
+
+type contextKey struct{}
+
+// Span holds causal attribution for one unit of work.
+type Span struct {
+	TraceID    string
+	SpanID     string
+	ParentID   string
+	Attributes map[string]any
+}
+
+// SetAttribute stores an arbitrary key-value pair on the span.
+func (s *Span) SetAttribute(key string, value any) {
+	if s.Attributes == nil {
+		s.Attributes = make(map[string]any)
+	}
+	s.Attributes[key] = value
+}
+
+// ContextWithSpan returns ctx with span embedded.
+func ContextWithSpan(ctx context.Context, s *Span) context.Context {
+	return context.WithValue(ctx, contextKey{}, s)
+}
+
+// SpanFromContext retrieves the active span from ctx, or nil.
+func SpanFromContext(ctx context.Context) *Span {
+	s, _ := ctx.Value(contextKey{}).(*Span)
+	return s
+}

--- a/sdk/go/span_test.go
+++ b/sdk/go/span_test.go
@@ -1,0 +1,32 @@
+package observr_test
+
+import (
+	"context"
+	"testing"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+)
+
+func TestSpanContextRoundTrip(t *testing.T) {
+	s := &observr.Span{
+		TraceID:  "abc123",
+		SpanID:   "def456",
+		ParentID: "",
+	}
+	ctx := observr.ContextWithSpan(context.Background(), s)
+	got := observr.SpanFromContext(ctx)
+	if got == nil {
+		t.Fatal("expected span in context, got nil")
+	}
+	if got.TraceID != "abc123" || got.SpanID != "def456" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestSpanSetAttribute(t *testing.T) {
+	s := &observr.Span{}
+	s.SetAttribute("intent", "summarize")
+	if s.Attributes["intent"] != "summarize" {
+		t.Fatal("attribute not set")
+	}
+}

--- a/sdk/go/traceparent.go
+++ b/sdk/go/traceparent.go
@@ -24,7 +24,11 @@ func ParseTraceparent(header string) (*Span, error) {
 }
 
 // FormatTraceparent formats a Span as a W3C traceparent header value.
+// Returns an empty string if s is nil.
 func FormatTraceparent(s *Span) string {
+	if s == nil {
+		return ""
+	}
 	return fmt.Sprintf("00-%s-%s-01", s.TraceID, s.SpanID)
 }
 

--- a/sdk/go/traceparent.go
+++ b/sdk/go/traceparent.go
@@ -6,20 +6,26 @@ import (
 	"strings"
 )
 
+var errInvalidTraceparent = errors.New("observr: invalid traceparent header")
+
 // ParseTraceparent parses a W3C traceparent header.
 // The returned Span represents the remote parent: its SpanID is the parent-id
 // field from the header, so ObservrClient.Span() will correctly link to it.
 func ParseTraceparent(header string) (*Span, error) {
 	parts := strings.Split(header, "-")
 	if len(parts) != 4 || parts[0] != "00" {
-		return nil, errors.New("observr: invalid traceparent header")
+		return nil, errInvalidTraceparent
 	}
-	if !isLowercaseHex(parts[1], 32) || !isLowercaseHex(parts[2], 16) {
-		return nil, errors.New("observr: invalid traceparent header")
+	traceID, parentID, flags := parts[1], parts[2], parts[3]
+	if !isLowercaseHex(traceID, 32) || !isLowercaseHex(parentID, 16) || !isLowercaseHex(flags, 2) {
+		return nil, errInvalidTraceparent
+	}
+	if isAllZero(traceID) || isAllZero(parentID) {
+		return nil, errInvalidTraceparent
 	}
 	return &Span{
-		TraceID: parts[1],
-		SpanID:  parts[2],
+		TraceID: traceID,
+		SpanID:  parentID,
 	}, nil
 }
 
@@ -38,6 +44,15 @@ func isLowercaseHex(s string, length int) bool {
 	}
 	for _, c := range s {
 		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func isAllZero(s string) bool {
+	for _, c := range s {
+		if c != '0' {
 			return false
 		}
 	}

--- a/sdk/go/traceparent.go
+++ b/sdk/go/traceparent.go
@@ -1,0 +1,25 @@
+package observr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ParseTraceparent parses a W3C traceparent header into a Span.
+// The new SpanID is not set here — caller must generate one.
+func ParseTraceparent(header string) (*Span, error) {
+	parts := strings.Split(header, "-")
+	if len(parts) != 4 || parts[0] != "00" {
+		return nil, errors.New("observr: invalid traceparent header")
+	}
+	return &Span{
+		TraceID:  parts[1],
+		ParentID: parts[2],
+	}, nil
+}
+
+// FormatTraceparent formats a Span as a W3C traceparent header value.
+func FormatTraceparent(s *Span) string {
+	return fmt.Sprintf("00-%s-%s-01", s.TraceID, s.SpanID)
+}

--- a/sdk/go/traceparent.go
+++ b/sdk/go/traceparent.go
@@ -6,20 +6,36 @@ import (
 	"strings"
 )
 
-// ParseTraceparent parses a W3C traceparent header into a Span.
-// The new SpanID is not set here — caller must generate one.
+// ParseTraceparent parses a W3C traceparent header.
+// The returned Span represents the remote parent: its SpanID is the parent-id
+// field from the header, so ObservrClient.Span() will correctly link to it.
 func ParseTraceparent(header string) (*Span, error) {
 	parts := strings.Split(header, "-")
 	if len(parts) != 4 || parts[0] != "00" {
 		return nil, errors.New("observr: invalid traceparent header")
 	}
+	if !isLowercaseHex(parts[1], 32) || !isLowercaseHex(parts[2], 16) {
+		return nil, errors.New("observr: invalid traceparent header")
+	}
 	return &Span{
-		TraceID:  parts[1],
-		ParentID: parts[2],
+		TraceID: parts[1],
+		SpanID:  parts[2],
 	}, nil
 }
 
 // FormatTraceparent formats a Span as a W3C traceparent header value.
 func FormatTraceparent(s *Span) string {
 	return fmt.Sprintf("00-%s-%s-01", s.TraceID, s.SpanID)
+}
+
+func isLowercaseHex(s string, length int) bool {
+	if len(s) != length {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
 }

--- a/sdk/go/traceparent_test.go
+++ b/sdk/go/traceparent_test.go
@@ -15,8 +15,9 @@ func TestParseTraceparent(t *testing.T) {
 	if s.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
 		t.Fatalf("wrong trace id: %s", s.TraceID)
 	}
-	if s.ParentID != "00f067aa0ba902b7" {
-		t.Fatalf("wrong parent id: %s", s.ParentID)
+	// parent-id from the header is stored as SpanID so Span() links correctly.
+	if s.SpanID != "00f067aa0ba902b7" {
+		t.Fatalf("wrong span id: %s", s.SpanID)
 	}
 }
 
@@ -30,8 +31,15 @@ func TestFormatTraceparent(t *testing.T) {
 }
 
 func TestParseTraceparentInvalid(t *testing.T) {
-	_, err := observr.ParseTraceparent("bad-header")
-	if err == nil {
-		t.Fatal("expected error for invalid header")
+	cases := []string{
+		"bad-header",
+		"00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-00f067aa0ba902b7-01", // uppercase
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-short-01",            // span-id too short
+		"00-tooshort-00f067aa0ba902b7-01",                         // trace-id too short
+	}
+	for _, h := range cases {
+		if _, err := observr.ParseTraceparent(h); err == nil {
+			t.Errorf("expected error for header %q", h)
+		}
 	}
 }

--- a/sdk/go/traceparent_test.go
+++ b/sdk/go/traceparent_test.go
@@ -1,0 +1,37 @@
+package observr_test
+
+import (
+	"testing"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+)
+
+func TestParseTraceparent(t *testing.T) {
+	header := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	s, err := observr.ParseTraceparent(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("wrong trace id: %s", s.TraceID)
+	}
+	if s.ParentID != "00f067aa0ba902b7" {
+		t.Fatalf("wrong parent id: %s", s.ParentID)
+	}
+}
+
+func TestFormatTraceparent(t *testing.T) {
+	s := &observr.Span{TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "aabbccdd11223344"}
+	got := observr.FormatTraceparent(s)
+	want := "00-4bf92f3577b34da6a3ce929d0e0e4736-aabbccdd11223344-01"
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestParseTraceparentInvalid(t *testing.T) {
+	_, err := observr.ParseTraceparent("bad-header")
+	if err == nil {
+		t.Fatal("expected error for invalid header")
+	}
+}

--- a/sdk/go/traceparent_test.go
+++ b/sdk/go/traceparent_test.go
@@ -33,9 +33,12 @@ func TestFormatTraceparent(t *testing.T) {
 func TestParseTraceparentInvalid(t *testing.T) {
 	cases := []string{
 		"bad-header",
-		"00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-00f067aa0ba902b7-01", // uppercase
+		"00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-00f067aa0ba902b7-01", // uppercase trace-id
 		"00-4bf92f3577b34da6a3ce929d0e0e4736-short-01",            // span-id too short
 		"00-tooshort-00f067aa0ba902b7-01",                         // trace-id too short
+		"00-00000000000000000000000000000000-00f067aa0ba902b7-01", // all-zero trace-id
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01", // all-zero parent-id
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-ZZ", // invalid flags
 	}
 	for _, h := range cases {
 		if _, err := observr.ParseTraceparent(h); err == nil {

--- a/sdk/go/transport.go
+++ b/sdk/go/transport.go
@@ -3,7 +3,9 @@ package observr
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -17,6 +19,8 @@ type Transport struct {
 	url    string
 	queue  chan map[string]any
 	done   chan struct{}
+	once   sync.Once
+	wg     sync.WaitGroup
 	client *http.Client
 }
 
@@ -32,6 +36,7 @@ func NewTransport(collectorURL string) *Transport {
 
 // Start begins the background flush goroutine.
 func (t *Transport) Start() {
+	t.wg.Add(1)
 	go t.loop()
 }
 
@@ -43,24 +48,15 @@ func (t *Transport) Enqueue(event map[string]any) {
 	}
 }
 
-// Shutdown flushes remaining events and stops the goroutine.
+// Shutdown signals the goroutine to stop, waits for it to drain, then returns.
+// Safe to call multiple times.
 func (t *Transport) Shutdown() {
-	close(t.done)
-	var batch []map[string]any
-	for {
-		select {
-		case e := <-t.queue:
-			batch = append(batch, e)
-		default:
-			if len(batch) > 0 {
-				t.flush(batch)
-			}
-			return
-		}
-	}
+	t.once.Do(func() { close(t.done) })
+	t.wg.Wait()
 }
 
 func (t *Transport) loop() {
+	defer t.wg.Done()
 	ticker := time.NewTicker(flushInterval)
 	defer ticker.Stop()
 	var batch []map[string]any
@@ -74,7 +70,18 @@ func (t *Transport) loop() {
 				batch = nil
 			}
 		case <-t.done:
-			return
+			// Drain remaining events owned by this goroutine.
+			for {
+				select {
+				case e := <-t.queue:
+					batch = append(batch, e)
+				default:
+					if len(batch) > 0 {
+						t.flush(batch)
+					}
+					return
+				}
+			}
 		}
 	}
 }
@@ -93,5 +100,6 @@ func (t *Transport) flush(events []map[string]any) {
 	if err != nil {
 		return
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 }

--- a/sdk/go/transport.go
+++ b/sdk/go/transport.go
@@ -1,0 +1,97 @@
+package observr
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const (
+	queueSize     = 10_000
+	flushInterval = time.Second
+)
+
+// Transport batches events and POSTs them to the collector.
+type Transport struct {
+	url    string
+	queue  chan map[string]any
+	done   chan struct{}
+	client *http.Client
+}
+
+// NewTransport creates a Transport targeting collectorURL.
+func NewTransport(collectorURL string) *Transport {
+	return &Transport{
+		url:    collectorURL + "/events",
+		queue:  make(chan map[string]any, queueSize),
+		done:   make(chan struct{}),
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// Start begins the background flush goroutine.
+func (t *Transport) Start() {
+	go t.loop()
+}
+
+// Enqueue adds an event to the send queue. Drops silently if full.
+func (t *Transport) Enqueue(event map[string]any) {
+	select {
+	case t.queue <- event:
+	default:
+	}
+}
+
+// Shutdown flushes remaining events and stops the goroutine.
+func (t *Transport) Shutdown() {
+	close(t.done)
+	var batch []map[string]any
+	for {
+		select {
+		case e := <-t.queue:
+			batch = append(batch, e)
+		default:
+			if len(batch) > 0 {
+				t.flush(batch)
+			}
+			return
+		}
+	}
+}
+
+func (t *Transport) loop() {
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	var batch []map[string]any
+	for {
+		select {
+		case e := <-t.queue:
+			batch = append(batch, e)
+		case <-ticker.C:
+			if len(batch) > 0 {
+				t.flush(batch)
+				batch = nil
+			}
+		case <-t.done:
+			return
+		}
+	}
+}
+
+func (t *Transport) flush(events []map[string]any) {
+	body, err := json.Marshal(events)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest(http.MethodPost, t.url, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}

--- a/sdk/go/transport.go
+++ b/sdk/go/transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -102,4 +103,7 @@ func (t *Transport) flush(events []map[string]any) {
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		log.Printf("observr: collector returned %d", resp.StatusCode)
+	}
 }

--- a/sdk/go/transport_test.go
+++ b/sdk/go/transport_test.go
@@ -1,0 +1,59 @@
+package observr_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	observr "github.com/ydking0911/observr/sdk/go"
+)
+
+func TestTransportSendsEvent(t *testing.T) {
+	received := make(chan map[string]any, 10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var events []map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&events)
+		for _, e := range events {
+			received <- e
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	tr := observr.NewTransport(srv.URL)
+	tr.Start()
+	tr.Enqueue(map[string]any{"service": "test", "type": "log", "level": "info", "message": "hello"})
+
+	select {
+	case e := <-received:
+		if e["message"] != "hello" {
+			t.Fatalf("unexpected event: %v", e)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+	tr.Shutdown()
+}
+
+func TestTransportDrainsOnShutdown(t *testing.T) {
+	count := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var events []map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&events)
+		count += len(events)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	tr := observr.NewTransport(srv.URL)
+	tr.Start()
+	for i := 0; i < 5; i++ {
+		tr.Enqueue(map[string]any{"service": "t", "type": "log", "level": "info", "message": "x"})
+	}
+	tr.Shutdown()
+	if count < 5 {
+		t.Fatalf("expected 5 events flushed, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `sdk/go/` as a standalone Go module (`github.com/ydking0911/observr/sdk/go`) with **zero external dependencies** — stdlib only
- `Span` / `StartSpan` — creates a child span in `context.Context`, emits a `type: span` event on end
- `AgentSpan` / `StartAgentSpan` — thin wrapper that pre-populates `observr.intent`, `observr.tool`, `observr.model`, `observr.trigger` attributes; matches Python/Node SDK convention
- `Transport` — 10k-event buffered channel, 1s flush interval, graceful drain on `Shutdown()`
- W3C `traceparent` encode/decode — `ParseTraceparent` / `FormatTraceparent`
- `integrations/nethttp` — `net/http` middleware that injects a span into the request context and reads/writes the `traceparent` header for cross-service trace propagation
- Package-level singleton (`Init` / `GetClient`) for zero-boilerplate setup
- `example/main.go` — runnable end-to-end example
- CI: `test-go-sdk` job added to `ci.yml` (`go test ./... -race -timeout 60s`)

## Test plan

- [x] `TestSpanContextRoundTrip` — span stored and retrieved from context correctly
- [x] `TestSpanSetAttribute` — lazy attribute map initialisation
- [x] `TestParseTraceparent` / `TestFormatTraceparent` / `TestParseTraceparentInvalid` — W3C header round-trip and error path
- [x] `TestTransportSendsEvent` — event delivered to httptest server within flush interval
- [x] `TestTransportDrainsOnShutdown` — all queued events flushed before process exit
- [x] `TestClientSpanEmitsEvent` — span event has correct `type`, `message`, emitted via real HTTP
- [x] `TestClientAgentSpanSetsAttrs` — `observr.intent` / `observr.tool` present in emitted event
- [x] `TestMiddlewareInjectsSpan` — handler context contains a non-empty span
- [x] `TestMiddlewareReadsTraceparent` — trace ID inherited from incoming `traceparent` header
- [x] All 11 tests pass with `-race`

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go SDK 클라이언트 추가 — 스팬 생성/종료, 에이전트 메타데이터 포함 이벤트 전송
  * HTTP 미들웨어 통합 — 요청에서 traceparent 파싱·주입, 응답에 traceparent 설정
  * 트레이스 유틸리티 추가 — traceparent 파싱/포맷팅 및 Span 컨텍스트 관리
  * 전송(Transport) 배치 큐 및 비동기 전송·종료 시 드레인 지원

* **Tests**
  * 클라이언트, 미들웨어, 트랜스포트, traceparent 및 스팬 유닛 테스트 추가

* **Chores**
  * Go 1.22 CI 워크플로우, 모듈 설정 및 예제 프로그램 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ydking0911/observr/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->