### PR TITLE
feat(server): tamper-evident audit hash chain and verify endpoint (#43)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -114,9 +114,11 @@ observr는 이벤트 메시지를 정규화해 유사한 것들을 같은 finger
 <details>
 <summary><strong>감사 로그 — 로컬, 쿼리 가능, 영구 저장</strong></summary>
 
-모든 이벤트는 로컬 SQLite(WAL 모드)에 타임스탬프, 서비스 정보, 구조화된 속성과 함께 저장됩니다.
+모든 이벤트는 로컬 SQLite(WAL 모드)에 타임스탬프, 서비스 정보, 구조화된 속성, 위변조 감지를 위한 SHA-256 해시 체인과 함께 저장됩니다.
 
 쿼리 가능 필드: 레벨 · 서비스 · trace ID · 시간 범위 · HTTP path
+
+`GET /verify`로 무결성을 확인할 수 있습니다. 대시보드 헤더는 저장된 체인이 정상일 때 `chain ✓`, 과거 이벤트가 수정되거나 삭제되어 체인이 깨졌을 때 `chain ✗`를 표시합니다.
 
 </details>
 
@@ -208,6 +210,36 @@ $ observrd query --service my-agent --level error --last 200 --format json
 → 오류 3건 모두 span "tool.call" → parent "agent.decide" at 14:32:01
 → 근본 원인: agent.decide가 잘못된 입력을 tool.call에 전달
 ```
+
+---
+
+## 감사 무결성 검증
+
+각 이벤트는 삽입 시점의 canonical JSON과 `SHA256(prev_hash + event_json)` 값을 저장합니다. 체인을 다시 계산하면 과거 이벤트를 제자리에서 수정하거나, 로그 중간의 이벤트를 삭제한 경우 다음 링크가 깨져 감지됩니다.
+
+```bash
+curl http://localhost:7676/verify
+```
+
+```json
+{ "ok": true, "checked": 1042, "skipped": 0, "broken_at": null }
+```
+
+체인이 깨진 경우 `broken_at`은 저장된 hash가 더 이상 맞지 않는 첫 이벤트 ID입니다.
+
+```json
+{ "ok": false, "checked": 204, "skipped": 0, "broken_at": "evt_abc123" }
+```
+
+`skipped`는 이 기능 이전에 기록된 **레거시 row**(hash 없음) 개수입니다. 기존 DB를 제자리 업그레이드해도 안전합니다 — 이런 row는 "깨짐"이 아니라 "검증 불가(skipped)"로 처리되고, 검증은 첫 번째 hash 이벤트부터 이어집니다.
+
+**무엇을 막고, 무엇을 막지 못하는가.** 이 기능은 키 없는(unkeyed) 로컬 해시 체인이지 블록체인이 아닙니다. 한계를 정직하게 밝힙니다:
+
+- **감지함**: 제자리 수정 및 로그 중간 이벤트 삭제.
+- **꼬리 절단(tail truncation)은 감지하지 못함**: 가장 최근 N개 이벤트를 삭제하면 더 짧지만 내부적으로 일관된 체인이 남아 `ok`가 `true`로 유지됩니다. 이를 막으려면 외부 head anchor(head hash + 개수)가 필요하며, 이는 향후 과제입니다.
+- **DB 파일 쓰기 권한 공격자에게는 무력함**: hash가 키 없는 방식이라, row를 수정할 수 있는 사람은 이후 모든 hash를 다시 계산해 검증을 통과할 수 있습니다. 위변조 감지는 체인을 재계산할 수 없는 주체(우발적 손상, 해싱 로직이 없는 프로세스, 읽기 전용 내보내기 사본 등)에 대해서만 유효합니다. 키 기반(HMAC) 또는 외부 앵커 방식은 향후 과제입니다.
+- **분산 합의 없음**: 단일 노드 위변조 감지 전용.
+- **retention과의 긴장**: retention cleanup이 가장 오래된 row를 삭제하면, genesis 이벤트가 사라진 뒤 남은 prefix가 더 이상 빈 seed에서 시작하지 않으므로 `/verify`가 새 최古 row에서 broken을 보고합니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,11 @@ observr normalizes event messages and groups similar ones by fingerprint.
 <details>
 <summary><strong>Audit Log — local, queryable, persistent</strong></summary>
 
-All events are stored locally in SQLite (WAL mode) with full timestamps, service attribution, and structured attributes.
+All events are stored locally in SQLite (WAL mode) with full timestamps, service attribution, structured attributes, and a tamper-evident SHA-256 hash chain.
 
 Queryable by: level · service · trace ID · time range · HTTP path
+
+Verify integrity with `GET /verify`. The dashboard header shows `chain ✓` when the stored chain is intact and `chain ✗` when an older event was modified or deleted.
 
 </details>
 
@@ -205,6 +207,36 @@ $ observrd query --service my-agent --level error --last 200 --format json
 → 3 errors, all traced to span "tool.call" → parent "agent.decide" at 14:32:01
 → Root cause: agent.decide passed malformed input to tool.call
 ```
+
+---
+
+## Verify Audit Integrity
+
+Each inserted event stores its canonical JSON plus `SHA256(prev_hash + event_json)`. Recomputing the chain detects in-place tampering: modifying a past event, or deleting an event from the middle of the log, breaks the next link.
+
+```bash
+curl http://localhost:7676/verify
+```
+
+```json
+{ "ok": true, "checked": 1042, "skipped": 0, "broken_at": null }
+```
+
+If the chain is broken, `broken_at` is the first event ID whose stored hash no longer matches:
+
+```json
+{ "ok": false, "checked": 204, "skipped": 0, "broken_at": "evt_abc123" }
+```
+
+`skipped` counts leading **legacy rows** written before this feature existed. Upgrading an existing database in place is safe: those rows have no stored hash, so they are reported as unverifiable (`skipped`) rather than broken, and verification continues from the first hashed event.
+
+**What it protects against, and what it does not.** This is a local, unkeyed hash chain — not a blockchain. It is honest about its limits:
+
+- **Detects** in-place edits and deletion of events from the middle of the log.
+- **Does not detect tail truncation.** Deleting the most recent N events leaves a shorter but internally consistent chain, so `ok` stays `true`. Closing this gap requires an external head anchor (planned).
+- **Does not resist an attacker with write access to the database file.** Because the hash is unkeyed, anyone who can edit a row can recompute every following hash and pass verification. Tamper-evidence holds only against actors who cannot recompute the chain (e.g. accidental corruption, a process without the verification logic, or read-only-then-tampered exports). A keyed (HMAC) or externally anchored variant is future work.
+- **No distributed consensus.** Single-node tamper evidence only.
+- **Retention interaction.** Retention cleanup deletes the oldest rows; once the genesis events are gone, the surviving prefix no longer chains from the empty seed and `/verify` reports broken for the new oldest row.
 
 ---
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useEventStream } from "./hooks/useEventStream";
 import { usePatterns } from "./hooks/usePatterns";
 import { useCausalCorrelations } from "./hooks/useCausalCorrelations";
@@ -88,6 +88,14 @@ function exportEvents(events: ObservrEvent[], format: "json" | "csv") {
 type Tab = "events" | "patterns";
 type PatternView = "cards" | "table";
 type PatternGroupBy = "tool" | "intent" | "model" | "";
+type ChainStatus = "loading" | "ok" | "broken" | "unverified" | "unknown";
+
+interface VerifyResult {
+  ok: boolean;
+  checked: number;
+  skipped: number;
+  broken_at: string | null;
+}
 
 const SINCE_OPTIONS = ["15m", "1h", "6h", "24h"];
 
@@ -96,6 +104,7 @@ export default function App() {
   const [filters, setFilters] = useState<Filters>({ level: "", search: "" });
   const [activeTab, setActiveTab] = useState<Tab>("events");
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const [chainStatus, setChainStatus] = useState<ChainStatus>("loading");
 
   // Patterns tab state
   const [patternSince, setPatternSince] = useState("15m");
@@ -125,6 +134,50 @@ export default function App() {
     anomaliesOnly ? patterns.filter((p) => p.anomaly) : patterns
   ), [patterns, anomaliesOnly]);
   const anomalyCount = useMemo(() => patterns.filter((p) => p.anomaly).length, [patterns]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/verify", { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error("verify failed");
+        return res.json() as Promise<VerifyResult>;
+      })
+      .then((result) => {
+        if (!result.ok) { setChainStatus("broken"); return; }
+        // ok with no verified rows means the DB holds only legacy (pre-hash)
+        // events — nothing to vouch for, so don't claim a verified chain.
+        setChainStatus(result.checked === 0 ? "unverified" : "ok");
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") setChainStatus("unknown");
+      });
+    return () => controller.abort();
+  }, []);
+
+  const chainLabel = chainStatus === "ok"
+    ? "chain ✓"
+    : chainStatus === "broken"
+      ? "chain ✗"
+      : chainStatus === "loading"
+        ? "chain …"
+        : chainStatus === "unverified"
+          ? "chain –"
+          : "chain ?";
+  const chainTitle = chainStatus === "broken"
+    ? "Audit hash chain is broken"
+    : chainStatus === "unverified"
+      ? "No hashed events yet — legacy rows are unverifiable"
+      : "Audit hash chain status";
+  const chainColor = chainStatus === "ok"
+    ? "oklch(72% 0.18 145)"
+    : chainStatus === "broken"
+      ? "oklch(68% 0.20 28)"
+      : "oklch(78% 0.04 250)";
+  const chainBg = chainStatus === "ok"
+    ? "oklch(45% 0.14 145 / 0.22)"
+    : chainStatus === "broken"
+      ? "oklch(45% 0.17 28 / 0.24)"
+      : "oklch(55% 0.04 250 / 0.20)";
 
   return (
     <div
@@ -205,7 +258,25 @@ export default function App() {
             ))}
           </div>
         </div>
-        <StatusDot connected={connected} />
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+          <span
+            title={chainTitle}
+            style={{
+              minWidth: 68,
+              textAlign: "center",
+              fontSize: "var(--text-xs)",
+              background: chainBg,
+              color: chainColor,
+              padding: "2px 7px",
+              borderRadius: "4px",
+              fontWeight: 600,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {chainLabel}
+          </span>
+          <StatusDot connected={connected} />
+        </div>
       </header>
 
       {/* ── Metrics strip ──────────────────────────────────────────── */}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ graph TB
         store[("SQLite\n(WAL mode)\nAudit Log")]
         patterns["Patterns Engine\nBehavioral fingerprinting"]
         query["GET /query\nAudit Query API"]
+        verify["GET /verify\nHash-chain integrity"]
         ws["WebSocket /ws\nReal-time stream"]
         sse["GET /tail\nSSE stream"]
         broadcaster["multiBroadcaster\n(extension point)"]
@@ -39,6 +40,7 @@ graph TB
         broadcaster --> alerter
         store --> patterns
         store --> query
+        store --> verify
     end
 
     subgraph consumers["Consumers"]
@@ -54,6 +56,7 @@ graph TB
     sse --> cli
     query --> agent
     query --> compliance
+    verify --> browser
     broadcaster -.-> future
 ```
 
@@ -66,7 +69,7 @@ Agent takes action
   → SDK creates span with parent_span_id (links to causal parent)
   → SDK enqueues event (non-blocking, 10k queue)
   → Background thread batches + POSTs to :7676/events
-  → Collector validates + inserts into SQLite
+  → Collector validates + inserts into SQLite with raw_json + SHA-256 hash
   → multiBroadcaster fans out to WebSocket / SSE / alerter
   → Patterns engine fingerprints the message for behavioral grouping
 ```
@@ -83,7 +86,7 @@ Query the full tree: `observrd query --trace-id 4f2a1b3c --format json`
 
 ## Causal Attribution
 
-The `parent_span_id` field is the audit chain mechanism. When an agent action causes a subsequent action, the child span carries the parent's `span_id`. This allows full reconstruction of the decision tree:
+The `parent_span_id` field is the causal chain mechanism. When an agent action causes a subsequent action, the child span carries the parent's `span_id`. This allows full reconstruction of the decision tree:
 
 ```
 trace_id: 4f2a1b3c
@@ -94,6 +97,36 @@ trace_id: 4f2a1b3c
 ```
 
 Query the full tree: `observrd query --trace-id 4f2a1b3c --format json`
+
+---
+
+## Hash-Chain Integrity
+
+The SQLite audit log is tamper-evident. Every inserted event stores:
+
+- `raw_json`: the canonical JSON for the event after its ID is assigned
+- `hash`: `SHA256(prev_hash + raw_json)`, where `prev_hash` is the previous inserted event's hash
+
+`Store.Insert()` computes these values under the store write mutex, so concurrent inserts cannot race and fork the chain. Batches are chained internally: event N's hash becomes event N+1's `prev_hash`.
+
+`GET /verify` streams events in SQLite insertion order (`rowid ASC`), recomputes the chain one row at a time (O(1) memory), and returns the first broken event:
+
+```json
+{ "ok": true,  "checked": 1042, "skipped": 0, "broken_at": null }
+{ "ok": false, "checked": 204,  "skipped": 0, "broken_at": "evt_abc123" }
+```
+
+`checked` counts verified hashed events; `skipped` counts leading legacy rows (written before this feature) that carry no hash. A run of legacy rows before the first hashed event is treated as unverifiable, not broken — so an in-place upgrade does not produce a false `chain ✗`. A blank row appearing *after* hashed rows, however, means a previously-hashed event was deleted or blanked, and is reported as tampering.
+
+### Threat model and limits
+
+This is an unkeyed, single-node hash chain — deliberately simple, and honest about what it does not do:
+
+- **Detects** in-place edits and middle-of-log deletions (the following link no longer matches).
+- **Tail truncation is undetectable.** Removing the most recent N events yields a shorter but self-consistent chain. Detecting this needs a persisted/external head anchor (head hash + count), which is intentionally out of scope for v1 and tracked as future work.
+- **No resistance to a writer of the DB file.** The hash is unkeyed, so an attacker who can edit a row can recompute every subsequent hash and pass `/verify`. Tamper-evidence is meaningful only against actors that cannot recompute the chain (accidental corruption, processes lacking the hashing logic, exported/read-only copies). A keyed-MAC or off-box anchoring variant would raise this bar.
+- **No consensus or remote anchoring.**
+- **Retention tension.** `DeleteBefore` removes the oldest rows; once the genesis events are gone the surviving prefix no longer chains from the empty seed, so `/verify` reports broken at the new oldest row. Retention and full-history verification are inherently in tension for a pure hash chain.
 
 ---
 
@@ -144,6 +177,7 @@ server/
     ├── patterns/patterns.go       Normalize() + Fetch() — behavioral fingerprinting
     ├── webhook/alerter.go         Broadcaster impl; threshold alerting → Slack/Discord
     ├── query/query.go             GET /query — filter + format (JSON/CSV/text)
+    ├── verify/handler.go          GET /verify — recompute hash chain
     ├── tail/tail.go               GET /tail — SSE hub, filters level/service/type
     └── dashboard/hub.go           WebSocket hub; embeds React SPA
 ```
@@ -190,7 +224,9 @@ CREATE TABLE events (
     status_code INTEGER,
     duration_ms REAL,
     message     TEXT,
-    attributes  TEXT                  -- JSON blob
+    attributes  TEXT,                 -- JSON blob
+    raw_json    TEXT,                 -- canonical event JSON used for hashing
+    hash        TEXT                  -- SHA-256(prev_hash + raw_json)
 );
 -- Indexes: level, trace_id, timestamp, path
 ```
@@ -226,7 +262,7 @@ CREATE TABLE events (
 
 ```
 dashboard/src/
-├── App.tsx               Layout, stats computation, filter + trace state
+├── App.tsx               Layout, stats computation, filter + trace state, chain badge
 ├── types.ts              ObservrEvent (incl. parent_span_id), Stats, Pattern
 ├── hooks/
 │   ├── useEventStream.ts WebSocket + HTTP initial load

--- a/server/cmd/observrd/main.go
+++ b/server/cmd/observrd/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ydking0911/observr/server/internal/query"
 	"github.com/ydking0911/observr/server/internal/storage"
 	internaltail "github.com/ydking0911/observr/server/internal/tail"
+	"github.com/ydking0911/observr/server/internal/verify"
 	"github.com/ydking0911/observr/server/internal/webhook"
 )
 
@@ -95,6 +96,9 @@ func main() {
 	// Pattern detection API
 	mux.Handle("GET /patterns", patterns.NewHandler(store))
 	mux.Handle("GET /patterns/causal", patterns.NewCausalHandler(store))
+
+	// Audit hash-chain verification
+	mux.Handle("GET /verify", verify.NewHandler(store))
 
 	// WebSocket for real-time dashboard streaming
 	hub := dashboard.NewHub(store)
@@ -188,8 +192,8 @@ func main() {
 type multiBroadcaster struct {
 	ws       storage.Broadcaster
 	sse      storage.Broadcaster
-	alert    storage.Broadcaster // may be nil
-	patterns storage.Broadcaster // may be nil
+	alert    *webhook.Alerter    // may be nil
+	patterns *patterns.Persistor // may be nil
 }
 
 func (m *multiBroadcaster) Broadcast(e storage.Event) {

--- a/server/cmd/observrd/main_test.go
+++ b/server/cmd/observrd/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/ydking0911/observr/server/internal/storage"
+	"github.com/ydking0911/observr/server/internal/webhook"
 )
 
 func TestParseRetention(t *testing.T) {
@@ -51,3 +54,24 @@ func TestParseRetention(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiBroadcasterSkipsTypedNilOptionalSinks(t *testing.T) {
+	var alerter *webhook.Alerter
+	m := &multiBroadcaster{
+		ws:    nopBroadcaster{},
+		sse:   nopBroadcaster{},
+		alert: alerter,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Broadcast panicked with typed nil optional sink: %v", r)
+		}
+	}()
+
+	m.Broadcast(storage.Event{ID: "evt_test", Service: "svc", Type: "log", Level: "info"})
+}
+
+type nopBroadcaster struct{}
+
+func (nopBroadcaster) Broadcast(storage.Event) {}

--- a/server/internal/storage/store.go
+++ b/server/internal/storage/store.go
@@ -144,10 +144,13 @@ func (s *Store) Insert(events []Event) error {
 		if e.ID == "" {
 			e.ID = newID()
 		}
-		attrs, _ := json.Marshal(e.Attributes)
+		attrs, err := json.Marshal(e.Attributes)
+		if err != nil {
+			return fmt.Errorf("marshal attributes for event %d (%s): %w", i, e.ID, err)
+		}
 		raw, err := json.Marshal(e)
 		if err != nil {
-			return fmt.Errorf("marshal event for hash: %w", err)
+			return fmt.Errorf("marshal event %d (%s) for hash: %w", i, e.ID, err)
 		}
 		hash := hashEvent(string(raw), prevHash)
 		_, err = stmt.Exec(

--- a/server/internal/storage/store.go
+++ b/server/internal/storage/store.go
@@ -3,12 +3,14 @@ package storage
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -79,6 +81,14 @@ type Store struct {
 	db          *sql.DB
 	path        string
 	broadcaster Broadcaster
+	writeMu     sync.Mutex
+}
+
+// VerifyEvent is the minimal stored form needed to recompute the audit hash chain.
+type VerifyEvent struct {
+	ID      string `json:"id"`
+	RawJSON string `json:"raw_json"`
+	Hash    string `json:"hash"`
 }
 
 func Open(path string) (*Store, error) {
@@ -104,6 +114,9 @@ func (s *Store) SetBroadcaster(b Broadcaster) {
 // ── Write ──────────────────────────────────────────────────────────────────
 
 func (s *Store) Insert(events []Event) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -113,13 +126,18 @@ func (s *Store) Insert(events []Event) error {
 	stmt, err := tx.Prepare(`
 		INSERT INTO events
 		  (id, trace_id, span_id, parent_span_id, service, timestamp, type, level,
-		   method, path, status_code, duration_ms, message, attributes)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		   method, path, status_code, duration_ms, message, attributes, raw_json, hash)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	`)
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
+
+	prevHash, err := loadLastHash(tx)
+	if err != nil {
+		return err
+	}
 
 	for i := range events {
 		e := &events[i]
@@ -127,16 +145,22 @@ func (s *Store) Insert(events []Event) error {
 			e.ID = newID()
 		}
 		attrs, _ := json.Marshal(e.Attributes)
+		raw, err := json.Marshal(e)
+		if err != nil {
+			return fmt.Errorf("marshal event for hash: %w", err)
+		}
+		hash := hashEvent(string(raw), prevHash)
 		_, err = stmt.Exec(
 			e.ID, e.TraceID, e.SpanID, e.ParentSpanID, e.Service,
 			e.Timestamp.UTC().Format(time.RFC3339Nano),
 			e.Type, e.Level,
 			e.Method, e.Path, e.StatusCode, e.DurationMS,
-			e.Message, string(attrs),
+			e.Message, string(attrs), string(raw), hash,
 		)
 		if err != nil {
 			return err
 		}
+		prevHash = hash
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -211,6 +235,33 @@ func (s *Store) Query(f QueryFilter) ([]Event, error) {
 	return events, rows.Err()
 }
 
+// ForEachVerifyEvent streams events in insertion order (rowid ASC) and invokes
+// fn for each one. It loads a single row at a time so audit verification stays
+// O(1) in memory regardless of how large the audit log has grown. If fn returns
+// an error, iteration stops and that error is propagated to the caller.
+func (s *Store) ForEachVerifyEvent(fn func(VerifyEvent) error) error {
+	rows, err := s.db.Query(`
+		SELECT id, COALESCE(raw_json, ''), COALESCE(hash, '')
+		FROM events
+		ORDER BY rowid ASC
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var e VerifyEvent
+		if err := rows.Scan(&e.ID, &e.RawJSON, &e.Hash); err != nil {
+			return err
+		}
+		if err := fn(e); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 // ── Migration ──────────────────────────────────────────────────────────────
 
 func (s *Store) migrate() error {
@@ -229,7 +280,9 @@ func (s *Store) migrate() error {
 			status_code    INTEGER,
 			duration_ms    REAL,
 			message        TEXT,
-			attributes     TEXT
+			attributes     TEXT,
+			raw_json       TEXT,
+			hash           TEXT
 		);
 		CREATE INDEX IF NOT EXISTS idx_events_level     ON events(level);
 		CREATE INDEX IF NOT EXISTS idx_events_trace_id  ON events(trace_id);
@@ -267,6 +320,16 @@ func (s *Store) migrate() error {
 	if _, err := s.db.Exec(`ALTER TABLE events ADD COLUMN parent_span_id TEXT`); err != nil {
 		if !strings.Contains(err.Error(), "duplicate column name") {
 			return fmt.Errorf("migrate add parent_span_id: %w", err)
+		}
+	}
+	if _, err := s.db.Exec(`ALTER TABLE events ADD COLUMN raw_json TEXT`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return fmt.Errorf("migrate add raw_json: %w", err)
+		}
+	}
+	if _, err := s.db.Exec(`ALTER TABLE events ADD COLUMN hash TEXT`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return fmt.Errorf("migrate add hash: %w", err)
 		}
 	}
 	return nil
@@ -470,4 +533,32 @@ func newID() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return "evt_" + hex.EncodeToString(b)
+}
+
+func loadLastHash(tx *sql.Tx) (string, error) {
+	var hash sql.NullString
+	err := tx.QueryRow(`
+		SELECT hash
+		FROM events
+		WHERE hash IS NOT NULL AND hash != ''
+		ORDER BY rowid DESC
+		LIMIT 1
+	`).Scan(&hash)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return hash.String, nil
+}
+
+func hashEvent(rawJSON, prevHash string) string {
+	sum := sha256.Sum256([]byte(prevHash + rawJSON))
+	return hex.EncodeToString(sum[:])
+}
+
+// HashForVerify computes the audit-chain hash for stored raw event JSON.
+func HashForVerify(rawJSON, prevHash string) string {
+	return hashEvent(rawJSON, prevHash)
 }

--- a/server/internal/storage/store_test.go
+++ b/server/internal/storage/store_test.go
@@ -1,7 +1,9 @@
 package storage_test
 
 import (
+	"math"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -145,6 +147,60 @@ func TestInsertSetsIDIfEmpty(t *testing.T) {
 	got, _ := s.Query(storage.QueryFilter{Last: 1})
 	if got[0].ID == "" {
 		t.Error("expected non-empty ID to be assigned")
+	}
+}
+
+func TestInsertMarshalErrorIncludesBatchIndexAndEventID(t *testing.T) {
+	s := newTestStore(t)
+
+	err := s.Insert([]storage.Event{
+		{
+			ID:        "ok-event",
+			Service:   "svc",
+			Timestamp: time.Now().UTC(),
+			Type:      "log",
+			Level:     "info",
+			Message:   "ok",
+		},
+		{
+			ID:         "bad-event",
+			Service:    "svc",
+			Timestamp:  time.Now().UTC(),
+			Type:       "log",
+			Level:      "info",
+			Message:    "bad",
+			DurationMS: math.NaN(),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+	if !strings.Contains(err.Error(), "marshal event 1 (bad-event) for hash") {
+		t.Fatalf("expected event index and ID in error, got %q", err.Error())
+	}
+}
+
+func TestInsertAttributeMarshalErrorIncludesBatchIndexAndEventID(t *testing.T) {
+	s := newTestStore(t)
+
+	err := s.Insert([]storage.Event{
+		{
+			ID:        "bad-event",
+			Service:   "svc",
+			Timestamp: time.Now().UTC(),
+			Type:      "log",
+			Level:     "info",
+			Message:   "bad",
+			Attributes: map[string]any{
+				"unsupported": func() {},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+	if !strings.Contains(err.Error(), "marshal attributes for event 0 (bad-event)") {
+		t.Fatalf("expected event index and ID in error, got %q", err.Error())
 	}
 }
 

--- a/server/internal/storage/verify_test.go
+++ b/server/internal/storage/verify_test.go
@@ -1,0 +1,146 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newVerifyTestStore(t *testing.T) *Store {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "observr-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func collectVerify(t *testing.T, s *Store) []VerifyEvent {
+	t.Helper()
+	var rows []VerifyEvent
+	if err := s.ForEachVerifyEvent(func(e VerifyEvent) error {
+		rows = append(rows, e)
+		return nil
+	}); err != nil {
+		t.Fatalf("ForEachVerifyEvent: %v", err)
+	}
+	return rows
+}
+
+func TestInsertStoresHashChainRowsForVerify(t *testing.T) {
+	s := newVerifyTestStore(t)
+
+	events := []Event{
+		{ID: "evt_a", Service: "svc", Timestamp: time.Unix(10, 0).UTC(), Type: "log", Level: "info", Message: "first"},
+		{ID: "evt_b", Service: "svc", Timestamp: time.Unix(5, 0).UTC(), Type: "log", Level: "warn", Message: "second"},
+	}
+	if err := s.Insert(events); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	rows := collectVerify(t, s)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].ID != "evt_a" || rows[1].ID != "evt_b" {
+		t.Fatalf("verify must use insertion order, got %q then %q", rows[0].ID, rows[1].ID)
+	}
+	for _, row := range rows {
+		if row.RawJSON == "" {
+			t.Fatalf("expected raw_json for %s", row.ID)
+		}
+		if row.Hash == "" {
+			t.Fatalf("expected hash for %s", row.ID)
+		}
+	}
+	if rows[1].Hash == hashEvent(rows[1].RawJSON, "") {
+		t.Fatal("second row hash did not include previous hash")
+	}
+}
+
+func TestForEachVerifyEventExposesLegacyRowsAsEmpty(t *testing.T) {
+	s := newVerifyTestStore(t)
+
+	_, err := s.db.Exec(`
+		INSERT INTO events
+		  (id, service, timestamp, type, level, message, attributes)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, "evt_legacy", "svc", time.Unix(1, 0).UTC().Format(time.RFC3339Nano), "log", "info", "legacy", "{}")
+	if err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	rows := collectVerify(t, s)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].RawJSON != "" || rows[0].Hash != "" {
+		t.Fatalf("legacy row should expose empty raw_json/hash, got %+v", rows[0])
+	}
+}
+
+func TestHashEventIsDeterministic(t *testing.T) {
+	got := hashEvent(`{"id":"evt_a"}`, "previous")
+	if got == "" {
+		t.Fatal("expected non-empty hash")
+	}
+	if got != hashEvent(`{"id":"evt_a"}`, "previous") {
+		t.Fatal("hashEvent is not deterministic")
+	}
+	if got == hashEvent(`{"id":"evt_a"}`, "") {
+		t.Fatal("hashEvent did not include previous hash")
+	}
+}
+
+// I5: concurrent inserts are serialized by writeMu, so the rows must still form
+// a single valid chain when recomputed in insertion (rowid) order.
+func TestConcurrentInsertsProduceValidChain(t *testing.T) {
+	s := newVerifyTestStore(t)
+
+	const goroutines = 8
+	const perGoroutine = 25
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				ev := Event{
+					Service:   "svc",
+					Timestamp: time.Now().UTC(),
+					Type:      "log",
+					Level:     "info",
+					Message:   fmt.Sprintf("g%d-i%d", g, i),
+				}
+				if err := s.Insert([]Event{ev}); err != nil {
+					t.Errorf("Insert: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	rows := collectVerify(t, s)
+	if len(rows) != goroutines*perGoroutine {
+		t.Fatalf("expected %d rows, got %d", goroutines*perGoroutine, len(rows))
+	}
+	prev := ""
+	for i, row := range rows {
+		if row.Hash != hashEvent(row.RawJSON, prev) {
+			t.Fatalf("row %d (%s) breaks the chain", i, row.ID)
+		}
+		prev = row.Hash
+	}
+}

--- a/server/internal/verify/handler.go
+++ b/server/internal/verify/handler.go
@@ -1,0 +1,95 @@
+// Package verify handles GET /verify for audit hash-chain integrity checks.
+package verify
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ydking0911/observr/server/internal/storage"
+)
+
+type loader interface {
+	ForEachVerifyEvent(fn func(storage.VerifyEvent) error) error
+}
+
+// Result is the JSON response returned by GET /verify.
+//
+// Checked counts hashed events that were successfully verified. Skipped counts
+// leading legacy rows (written before the hash chain existed) that carry no hash
+// and are therefore unverifiable rather than broken. BrokenAt, when non-nil, is
+// the first event whose stored hash no longer matches the recomputed chain.
+type Result struct {
+	OK       bool    `json:"ok"`
+	Checked  int     `json:"checked"`
+	Skipped  int     `json:"skipped"`
+	BrokenAt *string `json:"broken_at"`
+}
+
+// NewHandler returns an HTTP handler that verifies the stored audit hash chain.
+func NewHandler(s loader) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result, err := Check(s)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}
+
+// errBroken stops streaming early once a tampered row is found.
+var errBroken = errors.New("chain broken")
+
+// Check streams the stored events in insertion order and recomputes the hash
+// chain. A run of legacy rows (empty raw_json/hash) before the first hashed
+// event is treated as unverifiable and skipped — those rows predate the chain,
+// so reporting them as broken would raise a false alarm on every upgraded DB.
+// Once the hashed segment begins, an empty row means a previously-hashed event
+// was deleted or blanked, which is reported as tampering.
+func Check(s loader) (Result, error) {
+	var (
+		prevHash string
+		checked  int
+		skipped  int
+		started  bool
+		broken   *string
+	)
+
+	err := s.ForEachVerifyEvent(func(event storage.VerifyEvent) error {
+		isLegacy := event.RawJSON == "" || event.Hash == ""
+
+		if !started {
+			if isLegacy {
+				skipped++
+				return nil
+			}
+			started = true
+		} else if isLegacy {
+			id := event.ID
+			broken = &id
+			return errBroken
+		}
+
+		if event.Hash != storage.HashForVerify(event.RawJSON, prevHash) {
+			id := event.ID
+			broken = &id
+			return errBroken
+		}
+		prevHash = event.Hash
+		checked++
+		return nil
+	})
+	if err != nil && !errors.Is(err, errBroken) {
+		return Result{}, fmt.Errorf("verify events: %w", err)
+	}
+
+	if broken != nil {
+		return Result{OK: false, Checked: checked, Skipped: skipped, BrokenAt: broken}, nil
+	}
+	return Result{OK: true, Checked: checked, Skipped: skipped, BrokenAt: nil}, nil
+}

--- a/server/internal/verify/handler_test.go
+++ b/server/internal/verify/handler_test.go
@@ -1,0 +1,191 @@
+package verify_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ydking0911/observr/server/internal/storage"
+	"github.com/ydking0911/observr/server/internal/verify"
+)
+
+func TestHandlerReportsOKForValidChain(t *testing.T) {
+	s := fakeLoader{events: validRows()}
+
+	result := getVerify(t, s)
+	if !result.OK {
+		t.Fatalf("expected ok response, got %+v", result)
+	}
+	if result.Checked != 3 {
+		t.Fatalf("Checked = %d, want 3", result.Checked)
+	}
+	if result.Skipped != 0 {
+		t.Fatalf("Skipped = %d, want 0", result.Skipped)
+	}
+	if result.BrokenAt != nil {
+		t.Fatalf("BrokenAt = %v, want nil", *result.BrokenAt)
+	}
+}
+
+func TestHandlerReportsFirstTamperedRow(t *testing.T) {
+	rows := validRows()
+	rows[1].RawJSON = `{"id":"evt_b","message":"changed"}`
+	s := fakeLoader{events: rows}
+
+	result := getVerify(t, s)
+	if result.OK {
+		t.Fatalf("expected broken response, got %+v", result)
+	}
+	// evt_a verified before the break; the broken row is not counted as checked.
+	if result.Checked != 1 {
+		t.Fatalf("Checked = %d, want 1", result.Checked)
+	}
+	if result.BrokenAt == nil || *result.BrokenAt != "evt_b" {
+		t.Fatalf("BrokenAt = %v, want evt_b", result.BrokenAt)
+	}
+}
+
+func TestHandlerReportsDeletedMiddleRow(t *testing.T) {
+	rows := validRows()
+	rows = []storage.VerifyEvent{rows[0], rows[2]}
+	s := fakeLoader{events: rows}
+
+	result := getVerify(t, s)
+	if result.OK {
+		t.Fatalf("expected broken response, got %+v", result)
+	}
+	if result.Checked != 1 {
+		t.Fatalf("Checked = %d, want 1", result.Checked)
+	}
+	if result.BrokenAt == nil || *result.BrokenAt != "evt_c" {
+		t.Fatalf("BrokenAt = %v, want evt_c", result.BrokenAt)
+	}
+}
+
+// C1: a DB upgraded in place has legacy rows (empty raw_json/hash) preceding
+// the first hashed event. Those rows are unverifiable, not tampered, so the
+// chain must report OK with a Skipped count — never a false "broken".
+func TestHandlerSkipsLeadingLegacyRowsAndVerifiesSuffix(t *testing.T) {
+	rows := append([]storage.VerifyEvent{
+		{ID: "evt_legacy1", RawJSON: "", Hash: ""},
+		{ID: "evt_legacy2", RawJSON: "", Hash: ""},
+	}, validRows()...)
+	s := fakeLoader{events: rows}
+
+	result := getVerify(t, s)
+	if !result.OK {
+		t.Fatalf("expected ok response for legacy prefix, got %+v", result)
+	}
+	if result.Skipped != 2 {
+		t.Fatalf("Skipped = %d, want 2", result.Skipped)
+	}
+	if result.Checked != 3 {
+		t.Fatalf("Checked = %d, want 3", result.Checked)
+	}
+	if result.BrokenAt != nil {
+		t.Fatalf("BrokenAt = %v, want nil", *result.BrokenAt)
+	}
+}
+
+// A blank row appearing *after* hashed rows means a previously-hashed event was
+// deleted or blanked — that is real tampering and must be reported.
+func TestHandlerReportsBlankRowAfterHashedRows(t *testing.T) {
+	rows := validRows()
+	rows[1].RawJSON = ""
+	rows[1].Hash = ""
+	s := fakeLoader{events: rows}
+
+	result := getVerify(t, s)
+	if result.OK {
+		t.Fatalf("expected broken response, got %+v", result)
+	}
+	if result.BrokenAt == nil || *result.BrokenAt != "evt_b" {
+		t.Fatalf("BrokenAt = %v, want evt_b", result.BrokenAt)
+	}
+}
+
+func TestHandlerReportsOKForEmptyDB(t *testing.T) {
+	s := fakeLoader{events: nil}
+
+	result := getVerify(t, s)
+	if !result.OK {
+		t.Fatalf("expected ok response for empty db, got %+v", result)
+	}
+	if result.Checked != 0 || result.Skipped != 0 {
+		t.Fatalf("Checked=%d Skipped=%d, want 0/0", result.Checked, result.Skipped)
+	}
+}
+
+func TestHandlerReportsOKForLegacyOnlyDB(t *testing.T) {
+	s := fakeLoader{events: []storage.VerifyEvent{
+		{ID: "evt_legacy1"},
+		{ID: "evt_legacy2"},
+	}}
+
+	result := getVerify(t, s)
+	if !result.OK {
+		t.Fatalf("expected ok for legacy-only db, got %+v", result)
+	}
+	if result.Checked != 0 || result.Skipped != 2 {
+		t.Fatalf("Checked=%d Skipped=%d, want 0/2", result.Checked, result.Skipped)
+	}
+}
+
+func TestHandlerReturns500OnLoaderError(t *testing.T) {
+	s := fakeLoader{err: errors.New("disk gone")}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/verify", nil)
+	verify.NewHandler(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func getVerify(t *testing.T, s fakeLoader) verify.Result {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/verify", nil)
+	verify.NewHandler(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var result verify.Result
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return result
+}
+
+type fakeLoader struct {
+	events []storage.VerifyEvent
+	err    error
+}
+
+func (f fakeLoader) ForEachVerifyEvent(fn func(storage.VerifyEvent) error) error {
+	if f.err != nil {
+		return f.err
+	}
+	for _, e := range f.events {
+		if err := fn(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validRows() []storage.VerifyEvent {
+	rawA := `{"id":"evt_a","message":"first"}`
+	hashA := storage.HashForVerify(rawA, "")
+	rawB := `{"id":"evt_b","message":"second"}`
+	hashB := storage.HashForVerify(rawB, hashA)
+	rawC := `{"id":"evt_c","message":"third"}`
+	hashC := storage.HashForVerify(rawC, hashB)
+	return []storage.VerifyEvent{
+		{ID: "evt_a", RawJSON: rawA, Hash: hashA},
+		{ID: "evt_b", RawJSON: rawB, Hash: hashB},
+		{ID: "evt_c", RawJSON: rawC, Hash: hashC},
+	}
+}


### PR DESCRIPTION
## Summary

  - Adds a tamper-evident SHA-256 hash chain for stored audit events
  - Stores each inserted event's canonical `raw_json` and computed `hash` in SQLite
  - Adds `GET /verify` to recompute the chain and report the first broken event
  - Adds a dashboard header badge showing `chain ✓` / `chain ✗` based on `/verify`
  - Documents the local hash-chain model, verification API, and known limitations
  - Fixes a typed-nil optional broadcaster panic when webhook alerts are disabled

  ## How it works

  Each inserted event is assigned an ID, serialized as canonical JSON, and chained with:

  ```text
  SHA256(prev_hash + raw_json)
```
  GET /verify reads events in insertion order, recomputes the chain, and returns:
  ```json
  { "ok": true, "checked": 1042, "broken_at": null }
```
  or, when integrity verification fails:
  ```json
  { "ok": false, "checked": 204, "broken_at": "evt_abc123" }
```
  This is a local tamper-evident hash chain, not a blockchain. It does not provide distributed consensus, external anchoring, or protection against a DB writer recomputing the full chain.

  ## Test plan

  - [x] storage tests: hash/raw_json persistence, insertion-order verification rows, deterministic hash computation
  - [x] verify tests: valid chain, tampered row, deleted middle row
  - [x] observrd regression test: optional typed-nil broadcaster does not panic
  - [x] Real smoke test: POST /events returns 202, then GET /verify returns ok=true
  - [x] Real tamper smoke test: manually edited SQLite raw_json, then GET /verify returns ok=false
  - [x] go vet ./...
  - [x] CGO_ENABLED=1 go build -o /private/tmp/observr-observrd ./cmd/observrd
  - [x] go test ./... -race -timeout 60s
  - [x] Dashboard build: npm run build

  Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 감사 로그 무결성 검증을 위한 해시 체인 기능 추가
  * 대시보드에 감사 체인 상태 배지(✓/✗) 표시
  * `GET /verify` 엔드포인트로 감사 로그 변조 여부 확인 가능

* **문서화**
  * 감사 로그 해시 체인 및 무결성 검증 프로세스 문서화
  * 아키텍처 다이어그램 및 설명 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->