### PR TITLE
feat(server): persisted chain head anchor to detect audit-log tail truncation (#46)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -130,7 +130,7 @@ observr는 이벤트 메시지를 정규화해 유사한 것들을 같은 finger
 
 쿼리 가능 필드: 레벨 · 서비스 · trace ID · 시간 범위 · HTTP path
 
-`GET /verify`로 무결성을 확인할 수 있습니다. 대시보드 헤더는 저장된 체인이 정상일 때 `chain ✓`, 과거 이벤트가 수정되거나 삭제되어 체인이 깨졌을 때 `chain ✗`를 표시합니다.
+`GET /verify`로 무결성을 확인할 수 있습니다. 대시보드 헤더는 저장된 체인이 정상일 때 `chain ✓`, 과거 이벤트가 수정되거나 삭제되어 체인이 깨졌을 때 `chain ✗`, 저장된 head anchor와 남은 row가 맞지 않는 꼬리 절단 상태를 별도로 표시합니다.
 
 </details>
 
@@ -234,24 +234,23 @@ curl http://localhost:7676/verify
 ```
 
 ```json
-{ "ok": true, "checked": 1042, "skipped": 0, "broken_at": null }
+{ "ok": true, "checked": 1042, "skipped": 0, "broken_at": null, "detail": null }
 ```
 
-체인이 깨진 경우 `broken_at`은 저장된 hash가 더 이상 맞지 않는 첫 이벤트 ID입니다.
+체인이 깨진 경우 `detail`이 실패 종류를 설명합니다. 제자리 수정이나 중간 삭제라면 `broken_at`은 저장된 hash가 더 이상 맞지 않는 첫 이벤트 ID입니다.
 
 ```json
-{ "ok": false, "checked": 204, "skipped": 0, "broken_at": "evt_abc123" }
+{ "ok": false, "checked": 204, "skipped": 0, "broken_at": "evt_abc123", "detail": "broken_link" }
 ```
 
-`skipped`는 이 기능 이전에 기록된 **레거시 row**(hash 없음) 개수입니다. 기존 DB를 제자리 업그레이드해도 안전합니다 — 이런 row는 "깨짐"이 아니라 "검증 불가(skipped)"로 처리되고, 검증은 첫 번째 hash 이벤트부터 이어집니다.
+`skipped`는 이 기능 이전에 기록된 **레거시 row**(hash 없음) 개수입니다. 기존 DB를 제자리 업그레이드해도 안전합니다 — 이런 row는 "깨짐"이 아니라 "검증 불가(skipped)"로 처리되고, 검증은 첫 번째 hash 이벤트부터 이어집니다. 이미 hash가 있는 기존 DB는 단일 head anchor(`head_hash`, 개수, 마지막 ID, retention 기준점)를 backfill하여 이후 검증에서 짧아진 꼬리를 감지할 수 있습니다.
 
 **무엇을 막고, 무엇을 막지 못하는가.** 이 기능은 키 없는(unkeyed) 로컬 해시 체인이지 블록체인이 아닙니다. 한계를 정직하게 밝힙니다:
 
-- **감지함**: 제자리 수정 및 로그 중간 이벤트 삭제.
-- **꼬리 절단(tail truncation)은 감지하지 못함**: 가장 최근 N개 이벤트를 삭제하면 더 짧지만 내부적으로 일관된 체인이 남아 `ok`가 `true`로 유지됩니다. 이를 막으려면 외부 head anchor(head hash + 개수)가 필요하며, 이는 향후 과제입니다.
+- **감지함**: 제자리 수정, 로그 중간 이벤트 삭제, 그리고 최신 row가 head anchor 갱신 없이 제거된 꼬리 절단(tail truncation). 꼬리 절단이면 `/verify`는 `ok: false`, `broken_at: null`, `detail: "tail_truncated"`를 반환합니다.
 - **DB 파일 쓰기 권한 공격자에게는 무력함**: hash가 키 없는 방식이라, row를 수정할 수 있는 사람은 이후 모든 hash를 다시 계산해 검증을 통과할 수 있습니다. 위변조 감지는 체인을 재계산할 수 없는 주체(우발적 손상, 해싱 로직이 없는 프로세스, 읽기 전용 내보내기 사본 등)에 대해서만 유효합니다. 키 기반(HMAC) 또는 외부 앵커 방식은 향후 과제입니다.
 - **분산 합의 없음**: 단일 노드 위변조 감지 전용.
-- **retention과의 긴장**: retention cleanup이 가장 오래된 row를 삭제하면, genesis 이벤트가 사라진 뒤 남은 prefix가 더 이상 빈 seed에서 시작하지 않으므로 `/verify`가 새 최古 row에서 broken을 보고합니다.
+- **retention 상호작용**: 정상 `DeleteBefore` cleanup은 보존된 suffix의 기준 anchor를 함께 전진시키므로 거짓 broken-chain 보고를 만들지 않습니다. Store 밖에서 DB를 직접 편집하면 여전히 위변조로 보고될 수 있습니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ All events are stored locally in SQLite (WAL mode) with full timestamps, service
 
 Queryable by: level · service · trace ID · time range · HTTP path
 
-Verify integrity with `GET /verify`. The dashboard header shows `chain ✓` when the stored chain is intact and `chain ✗` when an older event was modified or deleted.
+Verify integrity with `GET /verify`. The dashboard header shows `chain ✓` when the stored chain is intact, `chain ✗` when an older event was modified or deleted, and a distinct truncation state when the persisted head anchor no longer matches the retained rows.
 
 </details>
 
@@ -231,24 +231,23 @@ curl http://localhost:7676/verify
 ```
 
 ```json
-{ "ok": true, "checked": 1042, "skipped": 0, "broken_at": null }
+{ "ok": true, "checked": 1042, "skipped": 0, "broken_at": null, "detail": null }
 ```
 
-If the chain is broken, `broken_at` is the first event ID whose stored hash no longer matches:
+If the chain is broken, `detail` explains the failure. For an in-place edit or middle deletion, `broken_at` is the first event ID whose stored hash no longer matches:
 
 ```json
-{ "ok": false, "checked": 204, "skipped": 0, "broken_at": "evt_abc123" }
+{ "ok": false, "checked": 204, "skipped": 0, "broken_at": "evt_abc123", "detail": "broken_link" }
 ```
 
-`skipped` counts leading **legacy rows** written before this feature existed. Upgrading an existing database in place is safe: those rows have no stored hash, so they are reported as unverifiable (`skipped`) rather than broken, and verification continues from the first hashed event.
+`skipped` counts leading **legacy rows** written before this feature existed. Upgrading an existing database in place is safe: those rows have no stored hash, so they are reported as unverifiable (`skipped`) rather than broken, and verification continues from the first hashed event. Existing hashed databases are backfilled with a single persisted head anchor (`head_hash`, count, last ID, and retention base) so future verification can detect a shortened tail.
 
 **What it protects against, and what it does not.** This is a local, unkeyed hash chain — not a blockchain. It is honest about its limits:
 
-- **Detects** in-place edits and deletion of events from the middle of the log.
-- **Does not detect tail truncation.** Deleting the most recent N events leaves a shorter but internally consistent chain, so `ok` stays `true`. Closing this gap requires an external head anchor (planned).
+- **Detects** in-place edits, deletion of events from the middle of the log, and tail truncation where the newest rows were removed without advancing the persisted head anchor. In the tail case, `/verify` returns `ok: false`, `broken_at: null`, and `detail: "tail_truncated"`.
 - **Does not resist an attacker with write access to the database file.** Because the hash is unkeyed, anyone who can edit a row can recompute every following hash and pass verification. Tamper-evidence holds only against actors who cannot recompute the chain (e.g. accidental corruption, a process without the verification logic, or read-only-then-tampered exports). A keyed (HMAC) or externally anchored variant is future work.
 - **No distributed consensus.** Single-node tamper evidence only.
-- **Retention interaction.** Retention cleanup deletes the oldest rows; once the genesis events are gone, the surviving prefix no longer chains from the empty seed and `/verify` reports broken for the new oldest row.
+- **Retention interaction.** Retention cleanup advances the retained suffix base anchor, so normal `DeleteBefore` cleanup does not create a false broken-chain report. Direct database edits outside the store can still be reported as tampering.
 
 ---
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -88,13 +88,14 @@ function exportEvents(events: ObservrEvent[], format: "json" | "csv") {
 type Tab = "events" | "patterns";
 type PatternView = "cards" | "table";
 type PatternGroupBy = "tool" | "intent" | "model" | "";
-type ChainStatus = "loading" | "ok" | "broken" | "unverified" | "unknown";
+type ChainStatus = "loading" | "ok" | "broken" | "truncated" | "unverified" | "unknown";
 
 interface VerifyResult {
   ok: boolean;
   checked: number;
   skipped: number;
   broken_at: string | null;
+  detail: "broken_link" | "tail_truncated" | null;
 }
 
 const SINCE_OPTIONS = ["15m", "1h", "6h", "24h"];
@@ -143,7 +144,10 @@ export default function App() {
         return res.json() as Promise<VerifyResult>;
       })
       .then((result) => {
-        if (!result.ok) { setChainStatus("broken"); return; }
+        if (!result.ok) {
+          setChainStatus(result.detail === "tail_truncated" ? "truncated" : "broken");
+          return;
+        }
         // ok with no verified rows means the DB holds only legacy (pre-hash)
         // events — nothing to vouch for, so don't claim a verified chain.
         setChainStatus(result.checked === 0 ? "unverified" : "ok");
@@ -156,6 +160,8 @@ export default function App() {
 
   const chainLabel = chainStatus === "ok"
     ? "chain ✓"
+    : chainStatus === "truncated"
+      ? "chain tail"
     : chainStatus === "broken"
       ? "chain ✗"
       : chainStatus === "loading"
@@ -163,18 +169,24 @@ export default function App() {
         : chainStatus === "unverified"
           ? "chain –"
           : "chain ?";
-  const chainTitle = chainStatus === "broken"
+  const chainTitle = chainStatus === "truncated"
+    ? "Audit hash chain tail was truncated"
+    : chainStatus === "broken"
     ? "Audit hash chain is broken"
     : chainStatus === "unverified"
       ? "No hashed events yet — legacy rows are unverifiable"
       : "Audit hash chain status";
   const chainColor = chainStatus === "ok"
     ? "oklch(72% 0.18 145)"
+    : chainStatus === "truncated"
+      ? "oklch(78% 0.16 72)"
     : chainStatus === "broken"
       ? "oklch(68% 0.20 28)"
       : "oklch(78% 0.04 250)";
   const chainBg = chainStatus === "ok"
     ? "oklch(45% 0.14 145 / 0.22)"
+    : chainStatus === "truncated"
+      ? "oklch(50% 0.14 72 / 0.24)"
     : chainStatus === "broken"
       ? "oklch(45% 0.17 28 / 0.24)"
       : "oklch(55% 0.04 250 / 0.20)";

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,26 +107,27 @@ The SQLite audit log is tamper-evident. Every inserted event stores:
 - `raw_json`: the canonical JSON for the event after its ID is assigned
 - `hash`: `SHA256(prev_hash + raw_json)`, where `prev_hash` is the previous inserted event's hash
 
-`Store.Insert()` computes these values under the store write mutex, so concurrent inserts cannot race and fork the chain. Batches are chained internally: event N's hash becomes event N+1's `prev_hash`.
+`Store.Insert()` computes these values under the store write mutex and updates a single-row `chain_meta` head anchor in the same transaction, so concurrent inserts cannot race, fork the chain, or leave the persisted head behind. Batches are chained internally: event N's hash becomes event N+1's `prev_hash`.
 
 `GET /verify` streams events in SQLite insertion order (`rowid ASC`), recomputes the chain one row at a time (O(1) memory), and returns the first broken event:
 
 ```json
-{ "ok": true,  "checked": 1042, "skipped": 0, "broken_at": null }
-{ "ok": false, "checked": 204,  "skipped": 0, "broken_at": "evt_abc123" }
+{ "ok": true,  "checked": 1042, "skipped": 0, "broken_at": null,         "detail": null }
+{ "ok": false, "checked": 1042, "skipped": 0, "broken_at": null,         "detail": "tail_truncated" }
+{ "ok": false, "checked": 204,  "skipped": 0, "broken_at": "evt_abc123", "detail": "broken_link" }
 ```
 
-`checked` counts verified hashed events; `skipped` counts leading legacy rows (written before this feature) that carry no hash. A run of legacy rows before the first hashed event is treated as unverifiable, not broken — so an in-place upgrade does not produce a false `chain ✗`. A blank row appearing *after* hashed rows, however, means a previously-hashed event was deleted or blanked, and is reported as tampering.
+`checked` counts verified hashed events; `skipped` counts leading legacy rows (written before this feature) that carry no hash. A run of legacy rows before the first hashed event is treated as unverifiable, not broken — so an in-place upgrade does not produce a false `chain ✗`. Existing hashed databases without `chain_meta` are backfilled by scanning rows once and persisting the observed head. A blank row appearing *after* hashed rows, however, means a previously-hashed event was deleted or blanked, and is reported as tampering.
 
 ### Threat model and limits
 
 This is an unkeyed, single-node hash chain — deliberately simple, and honest about what it does not do:
 
 - **Detects** in-place edits and middle-of-log deletions (the following link no longer matches).
-- **Tail truncation is undetectable.** Removing the most recent N events yields a shorter but self-consistent chain. Detecting this needs a persisted/external head anchor (head hash + count), which is intentionally out of scope for v1 and tracked as future work.
+- **Detects** tail truncation when the newest rows are removed without updating `chain_meta`; verification sees fewer rows than the persisted count and returns `detail: "tail_truncated"`.
 - **No resistance to a writer of the DB file.** The hash is unkeyed, so an attacker who can edit a row can recompute every subsequent hash and pass `/verify`. Tamper-evidence is meaningful only against actors that cannot recompute the chain (accidental corruption, processes lacking the hashing logic, exported/read-only copies). A keyed-MAC or off-box anchoring variant would raise this bar.
 - **No consensus or remote anchoring.**
-- **Retention tension.** `DeleteBefore` removes the oldest rows; once the genesis events are gone the surviving prefix no longer chains from the empty seed, so `/verify` reports broken at the new oldest row. Retention and full-history verification are inherently in tension for a pure hash chain.
+- **Retention base anchor.** `DeleteBefore` advances `base_rowid` and `base_prev_hash` before removing old rows, so the retained suffix verifies from the correct seed and routine cleanup does not look like tampering.
 
 ---
 
@@ -290,7 +291,8 @@ dashboard/src/
 | Go single binary | Zero-dependency install. SQLite + web server + CLI in one file |
 | SQLite + WAL | Local/on-prem first. No external database. Immutable append-friendly |
 | `parent_span_id` in schema | Enables causal attribution without a separate graph store |
-| `Broadcaster` interface | Decouples audit sinks — on-chain anchoring adds zero existing code changes |
+| `Broadcaster` interface | Decouples audit sinks — remote/on-chain anchoring can add external evidence without rewriting storage |
+| `chain_meta` head anchor | Detects audit-log tail truncation and records the retained suffix base for retention-safe verification |
 | Patterns engine | Behavioral fingerprinting needed for compliance reports, not just debugging |
 | Python zero-deps SDK | `pip install observr` just works in any agent environment |
 | Background queue transport | Audit capture must never block the instrumented agent |

--- a/scripts/test_e2e.py
+++ b/scripts/test_e2e.py
@@ -224,6 +224,38 @@ def main():
         fail("Service name mismatch on some events")
         failed += 1
 
+    # ── 6. Hash-chain integrity ───────────────────────────────────────
+    header("6. Verifying audit hash chain")
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{COLLECTOR_PORT}/verify", timeout=3
+        ) as r:
+            verify_result = json.loads(r.read())
+    except Exception as e:
+        verify_result = None
+        fail(f"/verify request failed: {e}")
+        failed += 1
+
+    if verify_result is not None:
+        if verify_result.get("ok") is True:
+            checked = verify_result.get("checked", 0)
+            ok(f"Chain intact: checked={checked}, broken_at=None, detail=None")
+            passed += 1
+        else:
+            fail(
+                f"Chain broken: ok={verify_result.get('ok')}, "
+                f"broken_at={verify_result.get('broken_at')}, "
+                f"detail={verify_result.get('detail')}"
+            )
+            failed += 1
+
+        if verify_result.get("checked", 0) > 0:
+            ok(f"At least one hashed event verified ({verify_result['checked']} total)")
+            passed += 1
+        else:
+            fail("No events were hashed — chain verification skipped all rows")
+            failed += 1
+
     # ── Result ────────────────────────────────────────────────────────
     header("Result")
     total = passed + failed

--- a/server/internal/storage/store.go
+++ b/server/internal/storage/store.go
@@ -86,9 +86,20 @@ type Store struct {
 
 // VerifyEvent is the minimal stored form needed to recompute the audit hash chain.
 type VerifyEvent struct {
+	RowID   int64  `json:"rowid"`
 	ID      string `json:"id"`
 	RawJSON string `json:"raw_json"`
 	Hash    string `json:"hash"`
+}
+
+// ChainMeta is the persisted audit-chain anchor used to detect tail truncation.
+type ChainMeta struct {
+	HeadHash     string
+	Count        int
+	LastID       string
+	BaseRowID    int64
+	BasePrevHash string
+	UpdatedAt    time.Time
 }
 
 func Open(path string) (*Store, error) {
@@ -134,10 +145,13 @@ func (s *Store) Insert(events []Event) error {
 	}
 	defer stmt.Close()
 
-	prevHash, err := loadLastHash(tx)
+	meta, err := loadChainMetaTx(tx)
 	if err != nil {
 		return err
 	}
+	prevHash := meta.HeadHash
+	count := meta.Count
+	lastID := meta.LastID
 
 	for i := range events {
 		e := &events[i]
@@ -164,6 +178,21 @@ func (s *Store) Insert(events []Event) error {
 			return err
 		}
 		prevHash = hash
+		count++
+		lastID = e.ID
+	}
+
+	if len(events) > 0 {
+		if err := upsertChainMetaTx(tx, ChainMeta{
+			HeadHash:     prevHash,
+			Count:        count,
+			LastID:       lastID,
+			BaseRowID:    meta.BaseRowID,
+			BasePrevHash: meta.BasePrevHash,
+			UpdatedAt:    time.Now().UTC(),
+		}); err != nil {
+			return err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -279,7 +308,7 @@ func (s *Store) QueryByTrace(traceID string) ([]Event, error) {
 // an error, iteration stops and that error is propagated to the caller.
 func (s *Store) ForEachVerifyEvent(fn func(VerifyEvent) error) error {
 	rows, err := s.db.Query(`
-		SELECT id, COALESCE(raw_json, ''), COALESCE(hash, '')
+		SELECT rowid, id, COALESCE(raw_json, ''), COALESCE(hash, '')
 		FROM events
 		ORDER BY rowid ASC
 	`)
@@ -290,7 +319,7 @@ func (s *Store) ForEachVerifyEvent(fn func(VerifyEvent) error) error {
 
 	for rows.Next() {
 		var e VerifyEvent
-		if err := rows.Scan(&e.ID, &e.RawJSON, &e.Hash); err != nil {
+		if err := rows.Scan(&e.RowID, &e.ID, &e.RawJSON, &e.Hash); err != nil {
 			return err
 		}
 		if err := fn(e); err != nil {
@@ -298,6 +327,11 @@ func (s *Store) ForEachVerifyEvent(fn func(VerifyEvent) error) error {
 		}
 	}
 	return rows.Err()
+}
+
+// ChainMeta returns the current persisted chain anchor.
+func (s *Store) ChainMeta() (*ChainMeta, error) {
+	return loadChainMetaDB(s.db)
 }
 
 // ── Migration ──────────────────────────────────────────────────────────────
@@ -349,6 +383,16 @@ func (s *Store) migrate() error {
 		);
 		CREATE INDEX IF NOT EXISTS idx_patterns_updated_at ON patterns(updated_at);
 		CREATE INDEX IF NOT EXISTS idx_patterns_anomaly    ON patterns(anomaly);
+
+		CREATE TABLE IF NOT EXISTS chain_meta (
+			id             INTEGER PRIMARY KEY CHECK (id = 1),
+			head_hash      TEXT NOT NULL,
+			count          INTEGER NOT NULL,
+			last_id        TEXT NOT NULL,
+			base_rowid     INTEGER NOT NULL,
+			base_prev_hash TEXT NOT NULL,
+			updated_at     TEXT NOT NULL
+		);
 	`)
 	if err != nil {
 		return err
@@ -369,6 +413,9 @@ func (s *Store) migrate() error {
 		if !strings.Contains(err.Error(), "duplicate column name") {
 			return fmt.Errorf("migrate add hash: %w", err)
 		}
+	}
+	if err := s.backfillChainMeta(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -517,18 +564,85 @@ func (s *Store) DeleteStalePatterns(olderThan time.Time) error {
 // DeleteBefore removes events with a timestamp older than t and returns the
 // number of deleted rows.
 func (s *Store) DeleteBefore(t time.Time) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	meta, err := loadChainMetaTx(tx)
+	if err != nil {
+		return 0, err
+	}
+
+	var baseRowID sql.NullInt64
+	var baseHash sql.NullString
+	var deletedHashed int
+	if err := tx.QueryRow(`
+		SELECT rowid, hash
+		FROM events
+		WHERE datetime(timestamp) < datetime(?)
+		  AND rowid > ?
+		  AND raw_json IS NOT NULL AND raw_json != ''
+		  AND hash IS NOT NULL AND hash != ''
+		ORDER BY rowid DESC
+		LIMIT 1
+	`, t.UTC().Format(time.RFC3339Nano), meta.BaseRowID).Scan(&baseRowID, &baseHash); err != nil {
+		if err != sql.ErrNoRows {
+			return 0, err
+		}
+	}
+	if err := tx.QueryRow(`
+		SELECT COUNT(*)
+		FROM events
+		WHERE datetime(timestamp) < datetime(?)
+		  AND rowid > ?
+		  AND raw_json IS NOT NULL AND raw_json != ''
+		  AND hash IS NOT NULL AND hash != ''
+	`, t.UTC().Format(time.RFC3339Nano), meta.BaseRowID).Scan(&deletedHashed); err != nil {
+		return 0, err
+	}
+
 	// Use datetime() to compare so SQLite parses both sides as timestamps
 	// rather than relying on lexicographic TEXT ordering of RFC3339Nano
 	// strings (which can be unreliable when the fractional-second part
 	// has different widths, e.g. "...00Z" vs "...00.5Z").
-	res, err := s.db.Exec(
+	res, err := tx.Exec(
 		`DELETE FROM events WHERE datetime(timestamp) < datetime(?)`,
 		t.UTC().Format(time.RFC3339Nano),
 	)
 	if err != nil {
 		return 0, err
 	}
-	return res.RowsAffected()
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedHashed > 0 && baseRowID.Valid && baseHash.Valid {
+		meta.BaseRowID = baseRowID.Int64
+		meta.BasePrevHash = baseHash.String
+		meta.Count -= deletedHashed
+		if meta.Count < 0 {
+			meta.Count = 0
+		}
+		if meta.Count == 0 {
+			meta.HeadHash = meta.BasePrevHash
+			meta.LastID = ""
+		}
+		meta.UpdatedAt = time.Now().UTC()
+		if err := upsertChainMetaTx(tx, meta); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return affected, nil
 }
 
 // Vacuum reclaims disk space freed by prior deletions.
@@ -573,22 +687,138 @@ func newID() string {
 	return "evt_" + hex.EncodeToString(b)
 }
 
-func loadLastHash(tx *sql.Tx) (string, error) {
-	var hash sql.NullString
-	err := tx.QueryRow(`
-		SELECT hash
+func (s *Store) backfillChainMeta() error {
+	meta, err := loadChainMetaDB(s.db)
+	if err != nil {
+		return err
+	}
+	if meta != nil {
+		return nil
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, COALESCE(raw_json, ''), COALESCE(hash, '')
 		FROM events
-		WHERE hash IS NOT NULL AND hash != ''
-		ORDER BY rowid DESC
-		LIMIT 1
-	`).Scan(&hash)
+		ORDER BY rowid ASC
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	count := 0
+	headHash := ""
+	lastID := ""
+	started := false
+	for rows.Next() {
+		var id, rawJSON, hash string
+		if err := rows.Scan(&id, &rawJSON, &hash); err != nil {
+			return err
+		}
+		isLegacy := rawJSON == "" || hash == ""
+		if !started {
+			if isLegacy {
+				continue
+			}
+			started = true
+		}
+		if isLegacy {
+			break
+		}
+		headHash = hash
+		lastID = id
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if count == 0 {
+		return nil
+	}
+	return upsertChainMetaDB(s.db, ChainMeta{
+		HeadHash:  headHash,
+		Count:     count,
+		LastID:    lastID,
+		UpdatedAt: time.Now().UTC(),
+	})
+}
+
+func loadChainMetaDB(db *sql.DB) (*ChainMeta, error) {
+	return scanChainMeta(db.QueryRow(`
+		SELECT head_hash, count, last_id, base_rowid, base_prev_hash, updated_at
+		FROM chain_meta
+		WHERE id = 1
+	`))
+}
+
+func loadChainMetaTx(tx *sql.Tx) (ChainMeta, error) {
+	meta, err := scanChainMeta(tx.QueryRow(`
+		SELECT head_hash, count, last_id, base_rowid, base_prev_hash, updated_at
+		FROM chain_meta
+		WHERE id = 1
+	`))
+	if err != nil {
+		return ChainMeta{}, err
+	}
+	if meta == nil {
+		return ChainMeta{}, nil
+	}
+	return *meta, nil
+}
+
+type chainMetaRow interface {
+	Scan(dest ...any) error
+}
+
+func scanChainMeta(row chainMetaRow) (*ChainMeta, error) {
+	var meta ChainMeta
+	var updatedAt string
+	err := row.Scan(&meta.HeadHash, &meta.Count, &meta.LastID, &meta.BaseRowID, &meta.BasePrevHash, &updatedAt)
 	if err == sql.ErrNoRows {
-		return "", nil
+		return nil, nil
 	}
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return hash.String, nil
+	if updatedAt != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, updatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse chain_meta updated_at %q: %w", updatedAt, err)
+		}
+		meta.UpdatedAt = parsed
+	}
+	return &meta, nil
+}
+
+func upsertChainMetaDB(db *sql.DB, meta ChainMeta) error {
+	_, err := db.Exec(chainMetaUpsertSQL(),
+		meta.HeadHash, meta.Count, meta.LastID, meta.BaseRowID, meta.BasePrevHash,
+		meta.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	)
+	return err
+}
+
+func upsertChainMetaTx(tx *sql.Tx, meta ChainMeta) error {
+	_, err := tx.Exec(chainMetaUpsertSQL(),
+		meta.HeadHash, meta.Count, meta.LastID, meta.BaseRowID, meta.BasePrevHash,
+		meta.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	)
+	return err
+}
+
+func chainMetaUpsertSQL() string {
+	return `
+		INSERT INTO chain_meta
+		  (id, head_hash, count, last_id, base_rowid, base_prev_hash, updated_at)
+		VALUES (1, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			head_hash=excluded.head_hash,
+			count=excluded.count,
+			last_id=excluded.last_id,
+			base_rowid=excluded.base_rowid,
+			base_prev_hash=excluded.base_prev_hash,
+			updated_at=excluded.updated_at
+	`
 }
 
 func hashEvent(rawJSON, prevHash string) string {

--- a/server/internal/storage/verify_test.go
+++ b/server/internal/storage/verify_test.go
@@ -256,3 +256,36 @@ func TestOpenBackfillsChainMetaForExistingHashedRows(t *testing.T) {
 		t.Fatalf("unexpected backfilled meta: %+v", meta)
 	}
 }
+
+func TestDeleteBeforeAllHashedEventsResetsChainMeta(t *testing.T) {
+	s := newVerifyTestStore(t)
+	now := time.Now().UTC()
+	events := []Event{
+		{ID: "evt_a", Service: "svc", Timestamp: now.Add(-3 * time.Hour), Type: "log", Level: "info", Message: "a"},
+		{ID: "evt_b", Service: "svc", Timestamp: now.Add(-2 * time.Hour), Type: "log", Level: "info", Message: "b"},
+		{ID: "evt_c", Service: "svc", Timestamp: now.Add(-1 * time.Hour), Type: "log", Level: "info", Message: "c"},
+	}
+	if err := s.Insert(events); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// 모든 이벤트보다 미래 cutoff → 전체 삭제
+	deleted, err := s.DeleteBefore(now)
+	if err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if deleted != 3 {
+		t.Fatalf("deleted = %d, want 3", deleted)
+	}
+
+	meta, err := s.ChainMeta()
+	if err != nil {
+		t.Fatalf("ChainMeta: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("expected chain_meta to exist after full deletion")
+	}
+	if meta.Count != 0 {
+		t.Fatalf("meta.Count = %d after full deletion, want 0", meta.Count)
+	}
+}

--- a/server/internal/storage/verify_test.go
+++ b/server/internal/storage/verify_test.go
@@ -67,6 +67,23 @@ func TestInsertStoresHashChainRowsForVerify(t *testing.T) {
 	if rows[1].Hash == hashEvent(rows[1].RawJSON, "") {
 		t.Fatal("second row hash did not include previous hash")
 	}
+
+	meta, err := s.ChainMeta()
+	if err != nil {
+		t.Fatalf("ChainMeta: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("expected chain metadata")
+	}
+	if meta.Count != 2 {
+		t.Fatalf("meta.Count = %d, want 2", meta.Count)
+	}
+	if meta.HeadHash != rows[1].Hash {
+		t.Fatalf("meta.HeadHash = %q, want %q", meta.HeadHash, rows[1].Hash)
+	}
+	if meta.LastID != "evt_b" {
+		t.Fatalf("meta.LastID = %q, want evt_b", meta.LastID)
+	}
 }
 
 func TestForEachVerifyEventExposesLegacyRowsAsEmpty(t *testing.T) {
@@ -142,5 +159,100 @@ func TestConcurrentInsertsProduceValidChain(t *testing.T) {
 			t.Fatalf("row %d (%s) breaks the chain", i, row.ID)
 		}
 		prev = row.Hash
+	}
+
+	meta, err := s.ChainMeta()
+	if err != nil {
+		t.Fatalf("ChainMeta: %v", err)
+	}
+	if meta == nil || meta.Count != goroutines*perGoroutine {
+		t.Fatalf("meta.Count = %+v, want %d", meta, goroutines*perGoroutine)
+	}
+}
+
+func TestDeleteBeforeAdvancesChainBaseAnchor(t *testing.T) {
+	s := newVerifyTestStore(t)
+	events := []Event{
+		{ID: "evt_old", Service: "svc", Timestamp: time.Unix(10, 0).UTC(), Type: "log", Level: "info", Message: "old"},
+		{ID: "evt_keep1", Service: "svc", Timestamp: time.Unix(20, 0).UTC(), Type: "log", Level: "info", Message: "keep1"},
+		{ID: "evt_keep2", Service: "svc", Timestamp: time.Unix(30, 0).UTC(), Type: "log", Level: "info", Message: "keep2"},
+	}
+	if err := s.Insert(events); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	before := collectVerify(t, s)
+
+	deleted, err := s.DeleteBefore(time.Unix(15, 0).UTC())
+	if err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+
+	meta, err := s.ChainMeta()
+	if err != nil {
+		t.Fatalf("ChainMeta: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("expected chain metadata")
+	}
+	if meta.BaseRowID != before[0].RowID {
+		t.Fatalf("BaseRowID = %d, want %d", meta.BaseRowID, before[0].RowID)
+	}
+	if meta.BasePrevHash != before[0].Hash {
+		t.Fatalf("BasePrevHash = %q, want %q", meta.BasePrevHash, before[0].Hash)
+	}
+	if meta.Count != 2 {
+		t.Fatalf("Count = %d, want 2", meta.Count)
+	}
+	if meta.HeadHash != before[2].Hash {
+		t.Fatalf("HeadHash = %q, want %q", meta.HeadHash, before[2].Hash)
+	}
+}
+
+func TestOpenBackfillsChainMetaForExistingHashedRows(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "observr-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := []Event{
+		{ID: "evt_a", Service: "svc", Timestamp: time.Unix(10, 0).UTC(), Type: "log", Level: "info", Message: "a"},
+		{ID: "evt_b", Service: "svc", Timestamp: time.Unix(20, 0).UTC(), Type: "log", Level: "info", Message: "b"},
+	}
+	if err := s.Insert(events); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	rows := collectVerify(t, s)
+	if _, err := s.db.Exec(`DELETE FROM chain_meta`); err != nil {
+		t.Fatalf("delete chain_meta: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	meta, err := reopened.ChainMeta()
+	if err != nil {
+		t.Fatalf("ChainMeta: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("expected backfilled chain metadata")
+	}
+	if meta.Count != 2 || meta.HeadHash != rows[1].Hash || meta.LastID != "evt_b" {
+		t.Fatalf("unexpected backfilled meta: %+v", meta)
 	}
 }

--- a/server/internal/verify/handler.go
+++ b/server/internal/verify/handler.go
@@ -14,6 +14,18 @@ type loader interface {
 	ForEachVerifyEvent(fn func(storage.VerifyEvent) error) error
 }
 
+type chainMetaLoader interface {
+	ChainMeta() (*storage.ChainMeta, error)
+}
+
+// Detail identifies the class of integrity failure, when one is known.
+type Detail string
+
+const (
+	DetailBrokenLink    Detail = "broken_link"
+	DetailTailTruncated Detail = "tail_truncated"
+)
+
 // Result is the JSON response returned by GET /verify.
 //
 // Checked counts hashed events that were successfully verified. Skipped counts
@@ -25,6 +37,7 @@ type Result struct {
 	Checked  int     `json:"checked"`
 	Skipped  int     `json:"skipped"`
 	BrokenAt *string `json:"broken_at"`
+	Detail   *Detail `json:"detail"`
 }
 
 // NewHandler returns an HTTP handler that verifies the stored audit hash chain.
@@ -58,9 +71,25 @@ func Check(s loader) (Result, error) {
 		skipped  int
 		started  bool
 		broken   *string
+		meta     *storage.ChainMeta
 	)
 
+	if metaLoader, ok := s.(chainMetaLoader); ok {
+		var err error
+		meta, err = metaLoader.ChainMeta()
+		if err != nil {
+			return Result{}, fmt.Errorf("load chain meta: %w", err)
+		}
+		if meta != nil {
+			prevHash = meta.BasePrevHash
+			started = meta.BasePrevHash != ""
+		}
+	}
+
 	err := s.ForEachVerifyEvent(func(event storage.VerifyEvent) error {
+		if meta != nil && event.RowID <= meta.BaseRowID {
+			return nil
+		}
 		isLegacy := event.RawJSON == "" || event.Hash == ""
 
 		if !started {
@@ -89,7 +118,18 @@ func Check(s loader) (Result, error) {
 	}
 
 	if broken != nil {
-		return Result{OK: false, Checked: checked, Skipped: skipped, BrokenAt: broken}, nil
+		detail := DetailBrokenLink
+		return Result{OK: false, Checked: checked, Skipped: skipped, BrokenAt: broken, Detail: &detail}, nil
 	}
-	return Result{OK: true, Checked: checked, Skipped: skipped, BrokenAt: nil}, nil
+	if meta != nil {
+		if checked < meta.Count {
+			detail := DetailTailTruncated
+			return Result{OK: false, Checked: checked, Skipped: skipped, BrokenAt: nil, Detail: &detail}, nil
+		}
+		if checked != meta.Count || (checked > 0 && prevHash != meta.HeadHash) {
+			detail := DetailBrokenLink
+			return Result{OK: false, Checked: checked, Skipped: skipped, BrokenAt: nil, Detail: &detail}, nil
+		}
+	}
+	return Result{OK: true, Checked: checked, Skipped: skipped, BrokenAt: nil, Detail: nil}, nil
 }

--- a/server/internal/verify/handler_test.go
+++ b/server/internal/verify/handler_test.go
@@ -1,11 +1,14 @@
 package verify_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/ydking0911/observr/server/internal/storage"
 	"github.com/ydking0911/observr/server/internal/verify"
@@ -27,6 +30,9 @@ func TestHandlerReportsOKForValidChain(t *testing.T) {
 	if result.BrokenAt != nil {
 		t.Fatalf("BrokenAt = %v, want nil", *result.BrokenAt)
 	}
+	if result.Detail != nil {
+		t.Fatalf("Detail = %v, want nil", *result.Detail)
+	}
 }
 
 func TestHandlerReportsFirstTamperedRow(t *testing.T) {
@@ -45,6 +51,9 @@ func TestHandlerReportsFirstTamperedRow(t *testing.T) {
 	if result.BrokenAt == nil || *result.BrokenAt != "evt_b" {
 		t.Fatalf("BrokenAt = %v, want evt_b", result.BrokenAt)
 	}
+	if result.Detail == nil || *result.Detail != verify.DetailBrokenLink {
+		t.Fatalf("Detail = %v, want broken_link", result.Detail)
+	}
 }
 
 func TestHandlerReportsDeletedMiddleRow(t *testing.T) {
@@ -61,6 +70,9 @@ func TestHandlerReportsDeletedMiddleRow(t *testing.T) {
 	}
 	if result.BrokenAt == nil || *result.BrokenAt != "evt_c" {
 		t.Fatalf("BrokenAt = %v, want evt_c", result.BrokenAt)
+	}
+	if result.Detail == nil || *result.Detail != verify.DetailBrokenLink {
+		t.Fatalf("Detail = %v, want broken_link", result.Detail)
 	}
 }
 
@@ -87,6 +99,9 @@ func TestHandlerSkipsLeadingLegacyRowsAndVerifiesSuffix(t *testing.T) {
 	if result.BrokenAt != nil {
 		t.Fatalf("BrokenAt = %v, want nil", *result.BrokenAt)
 	}
+	if result.Detail != nil {
+		t.Fatalf("Detail = %v, want nil", *result.Detail)
+	}
 }
 
 // A blank row appearing *after* hashed rows means a previously-hashed event was
@@ -103,6 +118,9 @@ func TestHandlerReportsBlankRowAfterHashedRows(t *testing.T) {
 	}
 	if result.BrokenAt == nil || *result.BrokenAt != "evt_b" {
 		t.Fatalf("BrokenAt = %v, want evt_b", result.BrokenAt)
+	}
+	if result.Detail == nil || *result.Detail != verify.DetailBrokenLink {
+		t.Fatalf("Detail = %v, want broken_link", result.Detail)
 	}
 }
 
@@ -133,6 +151,102 @@ func TestHandlerReportsOKForLegacyOnlyDB(t *testing.T) {
 	}
 }
 
+func TestHandlerReportsTailTruncatedFromPersistedMeta(t *testing.T) {
+	rows := validRows()
+	s := fakeLoader{
+		events: rows[:2],
+		meta: &storage.ChainMeta{
+			HeadHash: rows[2].Hash,
+			Count:    3,
+			LastID:   "evt_c",
+		},
+	}
+
+	result := getVerify(t, s)
+	if result.OK {
+		t.Fatalf("expected tail-truncated response, got %+v", result)
+	}
+	if result.Checked != 2 {
+		t.Fatalf("Checked = %d, want 2", result.Checked)
+	}
+	if result.BrokenAt != nil {
+		t.Fatalf("BrokenAt = %v, want nil", *result.BrokenAt)
+	}
+	if result.Detail == nil || *result.Detail != verify.DetailTailTruncated {
+		t.Fatalf("Detail = %v, want tail_truncated", result.Detail)
+	}
+}
+
+func TestHandlerReportsTailTruncatedAfterDirectLatestRowDelete(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "observr-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err := storage.Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.Insert([]storage.Event{
+		{ID: "evt_a", Service: "svc", Timestamp: time.Unix(10, 0).UTC(), Type: "log", Level: "info", Message: "first"},
+		{ID: "evt_b", Service: "svc", Timestamp: time.Unix(20, 0).UTC(), Type: "log", Level: "info", Message: "second"},
+		{ID: "evt_c", Service: "svc", Timestamp: time.Unix(30, 0).UTC(), Type: "log", Level: "info", Message: "third"},
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	db, err := sql.Open("sqlite3", f.Name()+"?_journal=WAL&_timeout=5000")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`DELETE FROM events WHERE id = ?`, "evt_c"); err != nil {
+		t.Fatalf("delete latest row: %v", err)
+	}
+
+	result := getVerify(t, s)
+	if result.OK {
+		t.Fatalf("expected tail-truncated response, got %+v", result)
+	}
+	if result.Checked != 2 {
+		t.Fatalf("Checked = %d, want 2", result.Checked)
+	}
+	if result.BrokenAt != nil {
+		t.Fatalf("BrokenAt = %v, want nil", *result.BrokenAt)
+	}
+	if result.Detail == nil || *result.Detail != verify.DetailTailTruncated {
+		t.Fatalf("Detail = %v, want tail_truncated", result.Detail)
+	}
+}
+
+func TestHandlerVerifiesRetainedSuffixFromBaseAnchor(t *testing.T) {
+	rows := validRows()
+	s := fakeLoader{
+		events: rows[1:],
+		meta: &storage.ChainMeta{
+			HeadHash:     rows[2].Hash,
+			Count:        2,
+			LastID:       "evt_c",
+			BaseRowID:    rows[0].RowID,
+			BasePrevHash: rows[0].Hash,
+		},
+	}
+
+	result := getVerify(t, s)
+	if !result.OK {
+		t.Fatalf("expected retained suffix to verify, got %+v", result)
+	}
+	if result.Checked != 2 {
+		t.Fatalf("Checked = %d, want 2", result.Checked)
+	}
+	if result.Detail != nil {
+		t.Fatalf("Detail = %v, want nil", *result.Detail)
+	}
+}
+
 func TestHandlerReturns500OnLoaderError(t *testing.T) {
 	s := fakeLoader{err: errors.New("disk gone")}
 
@@ -144,7 +258,12 @@ func TestHandlerReturns500OnLoaderError(t *testing.T) {
 	}
 }
 
-func getVerify(t *testing.T, s fakeLoader) verify.Result {
+type testLoader interface {
+	ForEachVerifyEvent(fn func(storage.VerifyEvent) error) error
+	ChainMeta() (*storage.ChainMeta, error)
+}
+
+func getVerify(t *testing.T, s testLoader) verify.Result {
 	t.Helper()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/verify", nil)
@@ -161,6 +280,7 @@ func getVerify(t *testing.T, s fakeLoader) verify.Result {
 
 type fakeLoader struct {
 	events []storage.VerifyEvent
+	meta   *storage.ChainMeta
 	err    error
 }
 
@@ -176,6 +296,10 @@ func (f fakeLoader) ForEachVerifyEvent(fn func(storage.VerifyEvent) error) error
 	return nil
 }
 
+func (f fakeLoader) ChainMeta() (*storage.ChainMeta, error) {
+	return f.meta, nil
+}
+
 func validRows() []storage.VerifyEvent {
 	rawA := `{"id":"evt_a","message":"first"}`
 	hashA := storage.HashForVerify(rawA, "")
@@ -184,8 +308,8 @@ func validRows() []storage.VerifyEvent {
 	rawC := `{"id":"evt_c","message":"third"}`
 	hashC := storage.HashForVerify(rawC, hashB)
 	return []storage.VerifyEvent{
-		{ID: "evt_a", RawJSON: rawA, Hash: hashA},
-		{ID: "evt_b", RawJSON: rawB, Hash: hashB},
-		{ID: "evt_c", RawJSON: rawC, Hash: hashC},
+		{RowID: 1, ID: "evt_a", RawJSON: rawA, Hash: hashA},
+		{RowID: 2, ID: "evt_b", RawJSON: rawB, Hash: hashB},
+		{RowID: 3, ID: "evt_c", RawJSON: rawC, Hash: hashC},
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a `chain_meta` single-row SQLite table that persists the chain tip (`head_hash`, `count`, `last_id`) after every insert, enabling detection of tail truncation — the one tampering vector the #43 hash chain could not catch
- `Store.Insert()` updates the head anchor **inside the same transaction and write mutex** as the event rows, so the anchor is always consistent with the DB it describes
- `Store.DeleteBefore()` (retention cleanup) advances a base anchor (`base_rowid`, `base_prev_hash`) so legitimate retention does not trigger a false `chain ✗`
- `GET /verify` cross-checks the recomputed count and tip hash against `chain_meta`; reports tail truncation distinctly from in-place tampering via a new `detail` field
- Dashboard badge gains a third state: amber **`chain tail`** for tail truncation, distinct from green `chain ✓` and red `chain ✗`
- Existing DBs are backfilled on first `Open()` so upgrades from #43 require no manual migration

## How it works

On every `Insert`, the head anchor is written in the same transaction:

```text
chain_meta: { head_hash, count, last_id, base_rowid, base_prev_hash, updated_at }
```

`GET /verify` recomputes the chain starting from `base_rowid` and compares:

```text
computed_count < meta.count        →  tail_truncated   (rows deleted from the end)
computed_hash  ≠ meta.head_hash    →  broken_link      (in-place edit or truncation)
```

Response shape:

```json
{ "ok": true,  "checked": 1042, "skipped": 0, "broken_at": null,           "detail": null }
{ "ok": false, "checked": 1042, "skipped": 0, "broken_at": null,           "detail": "tail_truncated" }
{ "ok": false, "checked": 204,  "skipped": 0, "broken_at": "evt_abc123",   "detail": "broken_link" }
```

> **Limitation**: the anchor lives in the same SQLite file, so a DB writer with direct access can rewrite `chain_meta` too. This closes accidental truncation and processes lacking hashing logic — not a determined local attacker.

## Test plan

- [x] `TestDeleteBeforeAdvancesChainBaseAnchor` — partial retention advances base anchor correctly
- [x] `TestDeleteBeforeAllHashedEventsResetsChainMeta` — full retention resets `count` to 0 without false alarm
- [x] `TestOpenBackfillsChainMetaForExistingHashedRows` — upgrade from #43 backfills anchor on `Open()`
- [x] `TestHandlerReportsTailTruncatedFromPersistedMeta` — fake loader with mismatched count triggers `tail_truncated`
- [x] `TestHandlerReportsTailTruncatedAfterDirectLatestRowDelete` — real DB, SQLite-level row delete triggers `tail_truncated`
- [x] `TestHandlerVerifiesRetainedSuffixFromBaseAnchor` — suffix-only chain verifies OK after retention
- [x] E2E: `GET /verify` returns `ok=true`, `checked=6` after real SDK event ingestion
- [x] Browser: amber `chain tail` badge on tail truncation, green `chain ✓` on intact chain, red `chain ✗` on in-place tamper
- [x] `go test ./... -race -timeout 60s` — all packages pass
- [x] `go vet ./...` — clean
- [x] `npm run build` — dashboard build succeeds

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 감사 해시 체인 검증 결과에 잘림(truncated) 상태를 별도로 표시하고, 검증 응답에 더 구체적인 상태 정보가 포함됩니다.
  * 대시보드에서 체인 상태 배지와 안내 문구가 정상, 손상, 잘림 상태로 구분되어 표시됩니다.

* **문서**
  * 검증 안내와 아키텍처 설명이 최신 동작에 맞게 업데이트되었습니다.
  * 보존 정리와 체인 검증의 관계, 레거시 데이터 처리 방식이 더 명확해졌습니다.

* **테스트**
  * 체인 무결성, 잘림 상태, 재개 후 복원 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->